### PR TITLE
fix: 画像の sizes 修正・ヘッダーロゴをグラデーションテキストに変更

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             {/* ロゴ */}
             <div className="flex items-center">
               <Image
-                src="/logo/logo2.png"
+                src="/images/header_logo.png"
                 alt="YS Development Logo"
                 width={50}
                 height={50}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,9 +27,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               <Image
                 src="/images/header_logo.png"
                 alt="YS Development Logo"
-                width={50}
-                height={50}
-                className="mr-2 md:w-[60px] md:h-[60px]"
+                width={94}
+                height={40}
+                className="md:w-[113px] md:h-[48px]"
               />
               {/* <span className="hidden sm:block font-bold text-lg md:text-xl text-sky-600">
                 YSデベロップメント

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@
 
 import "./globals.css";
 import { Menu, X } from "lucide-react";
-import { Noto_Sans_JP } from "next/font/google";
-import Image from "next/image";
+import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
 import { type ReactNode, useState } from "react";
 
 const notoSansJP = Noto_Sans_JP({
@@ -13,28 +12,29 @@ const notoSansJP = Noto_Sans_JP({
   display: "swap",
 });
 
+const zenKakuGothic = Zen_Kaku_Gothic_New({
+  subsets: ["latin"],
+  weight: ["700"],
+  variable: "--font-zen-kaku",
+  display: "swap",
+});
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <html lang="ja" className={notoSansJP.variable}>
+    <html
+      lang="ja"
+      className={`${notoSansJP.variable} ${zenKakuGothic.variable}`}
+    >
       <body className="min-h-screen bg-background text-foreground font-[family-name:var(--font-noto-sans-jp)]">
         {/* ナビゲーション */}
         <header className="w-full border-b bg-white/80 backdrop-blur-md sticky top-0 z-50">
           <nav className="max-w-7xl mx-auto flex justify-between items-center py-3 px-4 md:py-4 md:px-6">
             {/* ロゴ */}
-            <div className="flex items-center">
-              <Image
-                src="/images/header_logo.png"
-                alt="YS Development Logo"
-                width={94}
-                height={40}
-                className="md:w-[113px] md:h-[48px]"
-              />
-              {/* <span className="hidden sm:block font-bold text-lg md:text-xl text-sky-600">
-                YSデベロップメント
-              </span> */}
-            </div>
+            <span className="font-[family-name:var(--font-zen-kaku)] font-bold text-lg md:text-xl tracking-widest bg-gradient-to-r from-sky-600 to-indigo-500 bg-clip-text text-transparent">
+              YSデベロップメント
+            </span>
 
             {/* PC用ナビ */}
             <ul className="hidden md:flex gap-6 lg:gap-8 text-sm font-medium">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -135,7 +135,7 @@ export default function Home() {
               src={slide.pcSrc}
               alt={slide.alt}
               fill
-              sizes="100vw"
+              sizes="(max-width: 767px) 0px, 100vw"
               className="object-cover hidden md:block"
               priority={index === 0}
             />
@@ -144,7 +144,7 @@ export default function Home() {
               src={slide.spSrc}
               alt={slide.alt}
               fill
-              sizes="100vw"
+              sizes="(max-width: 767px) 100vw, 0px"
               className="object-cover md:hidden"
               priority={index === 0}
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -135,6 +135,7 @@ export default function Home() {
               src={slide.pcSrc}
               alt={slide.alt}
               fill
+              sizes="100vw"
               className="object-cover hidden md:block"
               priority={index === 0}
             />
@@ -143,6 +144,7 @@ export default function Home() {
               src={slide.spSrc}
               alt={slide.alt}
               fill
+              sizes="100vw"
               className="object-cover md:hidden"
               priority={index === 0}
             />
@@ -419,6 +421,7 @@ export default function Home() {
                     src="/images/services/ai.png"
                     alt="AI・DX活用支援"
                     fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
                     className="object-cover"
                   />
                 </div>
@@ -445,6 +448,7 @@ export default function Home() {
                     src="/images/services/マーケ.png"
                     alt="Webマーケティング"
                     fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
                     className="object-cover"
                   />
                 </div>
@@ -471,6 +475,7 @@ export default function Home() {
                     src="/images/services/開発.png"
                     alt="ホームページ制作・アプリ開発"
                     fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
                     className="object-cover"
                   />
                 </div>


### PR DESCRIPTION
## Summary

- ヘッダーロゴを画像から Zen Kaku Gothic New フォント + グラデーションテキスト（sky-600 → indigo-500）に変更
- `fill` 画像に `sizes` prop を追加してパフォーマンス警告を解消
  - Hero PC/SP 画像: ブレークポイント別に `sizes` を分離
  - Service カード画像: `sizes="(max-width: 768px) 100vw, 33vw"` を追加

## Test plan

- [ ] ヘッダーのロゴがグラデーションテキストで表示されること
- [ ] ブラウザコンソールに `sizes` 関連の警告が出ないこと
- [ ] Vercel プレビューで PC / SP 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)