### PR TITLE
chore: git worktreeを使った並行開発ルールを追加

### DIFF
--- a/.claude/rules/worktree.md
+++ b/.claude/rules/worktree.md
@@ -1,0 +1,39 @@
+# Git Worktree ルール
+
+## 基本方針
+
+並行開発は **git worktree** を使う。同じリポジトリを別ディレクトリに展開することで、ブランチ切り替えなしに複数の作業を並行して進められる。
+
+## Worktree の作成
+
+```bash
+# origin/main から新しいブランチで worktree を作成
+git worktree add ../portfolio-<branch-name> -b <branch-name> origin/main
+```
+
+ディレクトリ名は `portfolio-<branch-name>` の形式に統一する。
+
+## Worktree の削除（ブランチマージ後）
+
+GitHub の「Automatically delete head branches」が有効なため、PR マージ時にリモートブランチは自動削除される。
+ローカルの worktree とブランチは手動で削除する：
+
+```bash
+# worktree を削除（ディレクトリごと削除される）
+git worktree remove ../portfolio-<branch-name>
+
+# ローカルブランチを削除
+git branch -d <branch-name>
+```
+
+## 現在の Worktree 一覧確認
+
+```bash
+git worktree list
+```
+
+## ルール
+
+- 新しい作業を始めるときは必ず worktree を作成する（既存ブランチ上で直接作業しない）
+- main ブランチの worktree（メインディレクトリ）では直接コミットしない
+- マージ済みの worktree は速やかに削除してディレクトリを整理する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ No test framework is configured.
 @.claude/rules/workflow.md
 @.claude/rules/docs.md
 @.claude/rules/env.md
+@.claude/rules/worktree.md
 
 ## Key Conventions
 


### PR DESCRIPTION
## 変更内容

### `.claude/rules/worktree.md`（新規）
- worktree の作成・削除手順を定義
- ディレクトリ命名規則（`portfolio-<branch-name>`）
- マージ後のローカル worktree・ブランチ削除手順
- 「新しい作業は必ず worktree を作成する」ルールを明文化

### `CLAUDE.md`
- `worktree.md` の参照を追加

### GitHub 設定変更
- 「Automatically delete head branches」を有効化（PR マージ時にリモートブランチを自動削除）

## 背景

並行開発を worktree で行うことを今回の作業で確立。同じミス（既存ブランチ上で直接作業する）を繰り返さないためにルールとして明文化。