### PR TITLE
chore: postgres-best-practicesプラグインを有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "postgres-best-practices@supabase-agent-skills": true
+  }
+}


### PR DESCRIPTION
## 変更内容

`.claude/settings.json` に `postgres-best-practices@supabase-agent-skills` プラグインを追加。

## 背景

Issue #50（Supabase でブログ記事データを管理）に向けて、Postgres のクエリ・スキーマ設計のベストプラクティスを参照できるようにする。