### PR TITLE
feat: @claudeメンションでPRレビューを実行するCIを追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,18 @@
+name: Claude PR Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## 概要

closes #52

PR のコメントで `@claude` とメンションすると Claude が自動でコードレビューを行う。

## 変更内容

- `.github/workflows/claude-review.yml` を追加
- トリガー: PR コメントに `@claude` が含まれるとき
- `anthropics/claude-code-action@beta` を使用

## 使い方

PR のコメント欄に以下のように書く：

```
@claude このPRをレビューしてください
```

## 事前設定（完了済み）

- `ANTHROPIC_API_KEY` を GitHub Secrets に登録済み