### PR TITLE
fix: LCP画像にpriorityプロパティを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -448,6 +448,7 @@ export default function Home() {
                     src="/images/services/マーケ.png"
                     alt="Webマーケティング"
                     fill
+                    priority
                     sizes="(max-width: 768px) 100vw, 33vw"
                     className="object-cover"
                   />


### PR DESCRIPTION
## 概要

`/images/services/マーケ.png` が LCP として検出されているため、`priority` プロパティを追加してプリロードされるようにする。

## 変更内容

- `src/app/page.tsx`: マーケ.png の `<Image>` に `priority` を追加

## 競合について

`page.tsx` の変更箇所（447行目付近）は `feat/supabase-knowledge` ブランチとは独立した1行の追加のみ。main にマージ後、他ブランチで `git merge main` すれば自動解決できる変更です。