### PR TITLE
feat: 記事投稿 API を作成（API キー認証）（Issue #61）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ SUPABASE_DB_PASSWORD=
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+
+# Blog API
+BLOG_API_KEY=your_blog_api_key_here

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,0 +1,79 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+import type { Database } from "@/types/supabase";
+
+function createServiceClient() {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+    process.env.SUPABASE_SERVICE_ROLE_KEY as string,
+  );
+}
+
+function authenticate(request: Request): boolean {
+  const auth = request.headers.get("Authorization");
+  if (!auth?.startsWith("Bearer ")) return false;
+  return auth.slice(7) === process.env.BLOG_API_KEY;
+}
+
+export async function POST(request: Request) {
+  if (!authenticate(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const {
+    title,
+    slug,
+    content,
+    excerpt,
+    category,
+    tags,
+    status,
+    published_at,
+  } = body;
+
+  if (!title || !slug || !content || !excerpt || !category) {
+    return NextResponse.json(
+      { error: "必須項目が不足しています" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServiceClient();
+
+  const { data: article, error: articleError } = await supabase
+    .from("articles")
+    .insert({
+      title,
+      slug,
+      content,
+      excerpt,
+      category,
+      status: status ?? "draft",
+      published_at: published_at ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (articleError) {
+    return NextResponse.json({ error: articleError.message }, { status: 500 });
+  }
+
+  if (Array.isArray(tags) && tags.length > 0) {
+    for (const tagName of tags) {
+      const { data: tag } = await supabase
+        .from("tags")
+        .upsert({ name: tagName }, { onConflict: "name" })
+        .select("id")
+        .single();
+
+      if (tag) {
+        await supabase
+          .from("article_tags")
+          .insert({ article_id: article.id, tag_id: tag.id });
+      }
+    }
+  }
+
+  return NextResponse.json({ id: article.id }, { status: 201 });
+}


### PR DESCRIPTION
## Summary

- `POST /api/articles` エンドポイントを追加
- `Authorization: Bearer <BLOG_API_KEY>` ヘッダーで認証
- `service_role` キーで RLS をバイパスして書き込み
- タグは `upsert` で重複防止、`article_tags` で紐付け

## リクエスト例

```bash
curl -X POST https://your-domain.com/api/articles \
  -H "Authorization: Bearer <BLOG_API_KEY>" \
  -H "Content-Type: application/json" \
  -d '{
    "title": "記事タイトル",
    "slug": "article-slug",
    "content": "# 本文\n\nMarkdown...",
    "excerpt": "概要文",
    "category": "技術",
    "tags": ["Next.js", "Supabase"],
    "status": "published",
    "published_at": "2026-04-04T00:00:00Z"
  }'
```

## Closes

Closes #61

## Test plan

- [ ] 正しい API キーで投稿できること
- [ ] 誤った API キーで 401 が返ること
- [ ] 必須項目欠落で 400 が返ること
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)