### PR TITLE
fix: footer を画面下部に固定（Issue #67）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       lang="ja"
       className={`${notoSansJP.variable} ${zenKakuGothic.variable}`}
     >
-      <body className="min-h-screen bg-background text-foreground font-[family-name:var(--font-noto-sans-jp)]">
+      <body className="min-h-screen flex flex-col bg-background text-foreground font-[family-name:var(--font-noto-sans-jp)]">
         {/* ナビゲーション */}
         <header className="w-full border-b bg-white/80 backdrop-blur-md sticky top-0 z-50">
           <nav className="max-w-7xl mx-auto flex justify-between items-center py-3 px-4 md:py-4 md:px-6">
@@ -151,7 +151,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           </div>
         </header>
 
-        <main className="w-full">{children}</main>
+        <main className="w-full flex-1">{children}</main>
 
         <footer className="border-t py-8 bg-gray-50">
           <div className="max-w-7xl mx-auto px-4 md:px-6">

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -5,8 +5,8 @@ import type { Database } from "@/types/supabase";
 export async function createClient() {
   const cookieStore = await cookies();
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
     { cookies: { getAll: () => cookieStore.getAll() } },
   );
 }


### PR DESCRIPTION
## Summary

- `<body>` に `flex flex-col` を追加
- `<main>` に `flex-1` を追加

コンテンツが少ないページでも footer が常に画面下部に表示されるようになります。

Closes #67

## Test plan

- [ ] ブログ記事詳細など、コンテンツが少ないページで footer が画面下部にあること
- [ ] ホームなど、既存ページのレイアウトが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)