### PR TITLE
style: ヘッダーナビゲーションのラベルを日本語に統一

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,9 +7,9 @@ import Link from "next/link";
 import { type ReactNode, useState } from "react";
 
 const NAV_LINKS = [
-  { label: "Services", href: "/#services" },
-  { label: "Works", href: "/#works" },
-  { label: "Knowledge", href: "/knowledge" },
+  { label: "サービス", href: "/#services" },
+  { label: "実績", href: "/#works" },
+  { label: "ナレッジ", href: "/knowledge" },
   { label: "お問い合わせ", href: "/contact" },
 ];
 


### PR DESCRIPTION
## Summary

- `Services` → `サービス`
- `Works` → `実績`
- `Knowledge` → `ナレッジ`
- `お問い合わせ` はすでに日本語のため変更なし

## Test plan

- [ ] PC・モバイル両方でナビゲーションラベルが日本語で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)