### PR TITLE
feat: Slack スラッシュコマンド用 API Route を追加

### DIFF
--- a/src/app/api/slack/dev/route.ts
+++ b/src/app/api/slack/dev/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { postToSlack, verifySlackSignature } from "@/lib/slack";
+
+const GITHUB_OWNER = "shimizuyuta";
+const GITHUB_REPO = "portfolio_2025";
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const signature = request.headers.get("x-slack-signature") ?? "";
+  const timestamp = request.headers.get("x-slack-request-timestamp") ?? "";
+  const signingSecret = process.env.SLACK_SIGNING_SECRET ?? "";
+
+  if (!verifySlackSignature(signingSecret, signature, timestamp, rawBody)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const text = params.get("text")?.trim() ?? "";
+  const responseUrl = params.get("response_url") ?? "";
+
+  // /dev start #123
+  const match = text.match(/^start\s+#?(\d+)$/);
+  if (match) {
+    const issueNumber = match[1];
+
+    await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/workflows/claude-implement.yml/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ref: "main",
+          inputs: { issue_number: issueNumber },
+        }),
+      },
+    );
+
+    await postToSlack(
+      responseUrl,
+      `🚀 Issue #${issueNumber} の実装を開始しました。\nGitHub Actions が起動しています...`,
+    );
+    return NextResponse.json({ response_type: "in_channel" });
+  }
+
+  return NextResponse.json({
+    text: "使い方:\n• `/dev start #<Issue番号>` — Issue の実装を開始",
+  });
+}

--- a/src/app/api/slack/issue/route.ts
+++ b/src/app/api/slack/issue/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { postToSlack, verifySlackSignature } from "@/lib/slack";
+
+const GITHUB_OWNER = "shimizuyuta";
+const GITHUB_REPO = "portfolio_2025";
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const signature = request.headers.get("x-slack-signature") ?? "";
+  const timestamp = request.headers.get("x-slack-request-timestamp") ?? "";
+  const signingSecret = process.env.SLACK_SIGNING_SECRET ?? "";
+
+  if (!verifySlackSignature(signingSecret, signature, timestamp, rawBody)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const text = params.get("text")?.trim() ?? "";
+  const responseUrl = params.get("response_url") ?? "";
+
+  // /issue list
+  if (text === "list") {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues?state=open&per_page=10`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+        },
+      },
+    );
+    const issues = await res.json();
+
+    if (!Array.isArray(issues) || issues.length === 0) {
+      await postToSlack(responseUrl, "オープンな Issue はありません。");
+      return NextResponse.json({ response_type: "in_channel" });
+    }
+
+    const list = issues
+      .map(
+        (i: { number: number; title: string; html_url: string }) =>
+          `• #${i.number} ${i.title}\n  ${i.html_url}`,
+      )
+      .join("\n");
+
+    await postToSlack(responseUrl, `*オープンな Issue 一覧*\n${list}`);
+    return NextResponse.json({ response_type: "in_channel" });
+  }
+
+  // /issue create <title>
+  if (text.startsWith("create ")) {
+    const title = text.replace(/^create\s+/, "");
+    if (!title) {
+      return NextResponse.json({
+        text: "タイトルを入力してください。例: `/issue create バグ修正`",
+      });
+    }
+
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title }),
+      },
+    );
+    const issue = await res.json();
+
+    await postToSlack(
+      responseUrl,
+      `✅ Issue を作成しました\n*#${issue.number} ${issue.title}*\n${issue.html_url}`,
+    );
+    return NextResponse.json({ response_type: "in_channel" });
+  }
+
+  return NextResponse.json({
+    text: "使い方:\n• `/issue create <タイトル>` — Issue を作成\n• `/issue list` — Issue 一覧を表示",
+  });
+}

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,0 +1,30 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export function verifySlackSignature(
+  signingSecret: string,
+  signature: string,
+  timestamp: string,
+  rawBody: string,
+): boolean {
+  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 60 * 5;
+  if (Number(timestamp) < fiveMinutesAgo) return false;
+
+  const baseString = `v0:${timestamp}:${rawBody}`;
+  const hmac = createHmac("sha256", signingSecret)
+    .update(baseString)
+    .digest("hex");
+  const computedSignature = `v0=${hmac}`;
+
+  return timingSafeEqual(
+    Buffer.from(computedSignature),
+    Buffer.from(signature),
+  );
+}
+
+export async function postToSlack(responseUrl: string, text: string) {
+  await fetch(responseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+}


### PR DESCRIPTION
## 概要

Issue #81 の一部。Slack スラッシュコマンドの Webhook 受け口を実装。

## 追加ファイル

- `src/lib/slack.ts` — Slack 署名検証・応答ユーティリティ
- `src/app/api/slack/issue/route.ts` — `/issue create` / `/issue list`
- `src/app/api/slack/dev/route.ts` — `/dev start #<番号>`

## 動作

| コマンド | 動作 |
|---|---|
| `/issue create <タイトル>` | GitHub Issue を作成して URL を返す |
| `/issue list` | オープン Issue 一覧を返す |
| `/dev start #123` | GitHub Actions `claude-implement.yml` を起動 |

## 残タスク（次の PR）

- GitHub Actions ワークフロー作成（Step 8: claude-implement.yml）
- Playwright スクショ → Slack 投稿（Step 9）
- 環境変数の Vercel 登録ガイド（Step 7）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)