### PR TITLE
feat: ブログ詳細ページのデザインをリニューアル

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "19.1.0",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "resend": "^6.9.4",
         "tailwind-merge": "^3.3.1"
@@ -2288,12 +2289,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
@@ -2329,6 +2349,19 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3948,6 +3981,23 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "resend": "^6.9.4",
     "tailwind-merge": "^3.3.1"

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
+import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
 import { getArticleBySlug } from "@/lib/knowledge";
@@ -9,6 +10,23 @@ import { getArticleBySlug } from "@/lib/knowledge";
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+// Markdownの見出し（## / ###）を抽出してToCを生成
+function extractHeadings(markdown: string) {
+  const lines = markdown.split("\n");
+  return lines
+    .filter((line) => /^#{2,3}\s/.test(line))
+    .map((line) => {
+      const level = line.match(/^(#{2,3})/)?.[1].length ?? 2;
+      const text = line.replace(/^#{2,3}\s+/, "").trim();
+      const id = text
+        .toLowerCase()
+        .replace(/[^\w\u3040-\u30FF\u4E00-\u9FFF\u3400-\u4DBF]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+      return { level, text, id };
+    });
+}
 
 export default async function ArticlePage({ params }: Props) {
   const { slug } = await params;
@@ -18,42 +36,139 @@ export default async function ArticlePage({ params }: Props) {
     notFound();
   }
 
-  return (
-    <main className="max-w-3xl mx-auto px-4 md:px-6 py-16 md:py-24">
-      <Link
-        href="/knowledge"
-        className="text-sm text-muted-foreground hover:text-foreground mb-8 inline-block"
-      >
-        ← Knowledge 一覧へ
-      </Link>
+  const headings = extractHeadings(article.content);
+  const publishedDate = article.published_at
+    ? new Date(article.published_at).toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
 
-      <article>
-        <div className="flex items-center gap-2 mb-4">
-          <Badge variant="outline">{article.category}</Badge>
+  return (
+    <div className="bg-white min-h-screen">
+      {/* パンくずナビ */}
+      <div className="border-b bg-gray-50">
+        <nav
+          aria-label="パンくずリスト"
+          className="max-w-4xl mx-auto px-4 md:px-6 py-3"
+        >
+          <ol className="flex items-center gap-1.5 text-xs text-gray-500 flex-wrap">
+            <li>
+              <Link href="/" className="hover:text-sky-600 transition-colors">
+                Top
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href="/knowledge"
+                className="hover:text-sky-600 transition-colors"
+              >
+                Blog
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-gray-800 font-medium line-clamp-1">
+              {article.title}
+            </li>
+          </ol>
+        </nav>
+      </div>
+
+      <main className="max-w-4xl mx-auto px-4 md:px-6 py-10 md:py-16">
+        {/* ヒーロー画像 */}
+        <div className="w-full aspect-video rounded-2xl overflow-hidden bg-gray-100 mb-8 shadow-sm">
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-sky-50 to-indigo-100">
+            <span className="text-4xl font-bold text-sky-300/60 tracking-wider">
+              {article.category}
+            </span>
+          </div>
+        </div>
+
+        {/* メタ情報 */}
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <Badge className="bg-sky-50 text-sky-700 border border-sky-200 hover:bg-sky-50 text-xs">
+            {article.category}
+          </Badge>
           {article.tags.map((tag) => (
-            <Badge key={tag.id} variant="secondary">
+            <Badge key={tag.id} variant="secondary" className="text-xs">
               {tag.name}
             </Badge>
           ))}
+          {publishedDate && (
+            <time
+              dateTime={article.published_at ?? undefined}
+              className="text-xs text-gray-400 ml-auto"
+            >
+              {publishedDate}
+            </time>
+          )}
         </div>
 
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">{article.title}</h1>
+        {/* タイトル */}
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 leading-snug mb-10">
+          {article.title}
+        </h1>
 
-        <time className="text-sm text-muted-foreground mb-8 block">
-          {article.published_at
-            ? new Date(article.published_at).toLocaleDateString("ja-JP")
-            : ""}
-        </time>
+        {/* 目次 */}
+        {headings.length > 0 && (
+          <nav
+            aria-label="目次"
+            className="mb-10 rounded-xl border border-gray-200 bg-gray-50 px-6 py-5"
+          >
+            <p className="text-sm font-bold text-gray-700 mb-3">目次</p>
+            <ol className="space-y-2">
+              {headings.map((h, i) => (
+                <li key={h.id} className={h.level === 3 ? "pl-4" : ""}>
+                  <a
+                    href={`#${h.id}`}
+                    className="text-sm text-sky-600 hover:text-sky-800 hover:underline transition-colors flex gap-2"
+                  >
+                    <span className="text-gray-400 shrink-0 tabular-nums">
+                      {i + 1}.
+                    </span>
+                    {h.text}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        )}
 
-        <div className="prose prose-neutral dark:prose-invert max-w-none">
+        {/* 記事本文 */}
+        <div className="prose prose-neutral prose-headings:font-bold prose-headings:text-gray-900 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded max-w-none">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeHighlight]}
+            rehypePlugins={[rehypeHighlight, rehypeSlug]}
           >
             {article.content}
           </ReactMarkdown>
         </div>
-      </article>
-    </main>
+
+        {/* 戻るリンク */}
+        <div className="mt-16 pt-8 border-t">
+          <Link
+            href="/knowledge"
+            className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-sky-600 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M19 12H5M12 5l-7 7 7 7" />
+            </svg>
+            ブログ一覧へ戻る
+          </Link>
+        </div>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- パンくずナビ（Top / Blog / 記事タイトル）を追加
- ヒーロー画像エリア（サムネイル未実装時はカテゴリ名のグラデーションプレースホルダー）
- カテゴリ・タグ・公開日のメタ情報
- Markdownの `##` / `###` から目次を自動生成（`rehype-slug` でアンカーリンク対応）
- SNS シェアリンクは非搭載
- 「ブログ一覧へ戻る」リンクをフッターに配置

## Test plan

- [ ] `/knowledge/[slug]` にアクセスして新デザインが表示されること
- [ ] 目次のリンクをクリックで該当見出しにスクロールすること
- [ ] パンくずリンクが正しく機能すること
- [ ] 記事が存在しない場合に 404 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)