### PR TITLE
feat: Vercelビルド時にSupabase接続をスキップするgenerateStaticParamsを追加

### DIFF
--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -5,18 +5,16 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
-import { getAllArticleSlugs, getArticleBySlug } from "@/lib/knowledge";
+import { getArticleBySlug } from "@/lib/knowledge";
 
 type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export async function generateStaticParams() {
-  if (process.env.VERCEL === "1") {
-    return [];
-  }
-  const slugs = await getAllArticleSlugs();
-  return slugs.map((slug) => ({ slug }));
+// generateStaticParams でのビルド時 Supabase 接続を回避するため常に空配列を返す。
+// ページはリクエスト時にオンデマンドで SSR される。
+export function generateStaticParams() {
+  return [];
 }
 
 // Markdownの見出し（## / ###）を抽出してToCを生成

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -5,11 +5,19 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
-import { getArticleBySlug } from "@/lib/knowledge";
+import { getAllArticleSlugs, getArticleBySlug } from "@/lib/knowledge";
 
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+export async function generateStaticParams() {
+  if (process.env.VERCEL === "1") {
+    return [];
+  }
+  const slugs = await getAllArticleSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
 
 // Markdownの見出し（## / ###）を抽出してToCを生成
 function extractHeadings(markdown: string) {

--- a/src/lib/knowledge/index.ts
+++ b/src/lib/knowledge/index.ts
@@ -34,6 +34,15 @@ export async function getPublishedArticles(): Promise<Article[]> {
   }));
 }
 
+export async function getAllArticleSlugs(): Promise<string[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("articles")
+    .select("slug")
+    .eq("status", "published");
+  return data?.map((r) => r.slug) ?? [];
+}
+
 export async function getArticleBySlug(
   slug: string,
 ): Promise<Article | undefined> {


### PR DESCRIPTION
## Summary

- `VERCEL=1` の場合は `generateStaticParams` で空配列を返し、ビルド時の Supabase 接続をスキップ
- それ以外の環境（ローカル等）では `getAllArticleSlugs()` で公開記事の slug を取得して静的生成

## 変更ファイル

- `src/app/knowledge/[slug]/page.tsx` — `generateStaticParams` を追加
- `src/lib/knowledge/index.ts` — `getAllArticleSlugs()` を追加

## Test plan

- [ ] Vercel デプロイのビルドログで Supabase 接続エラーが出ないこと
- [ ] `VERCEL=1` を外した環境で slug が正しく返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)