### PR TITLE
feat: ローカル専用のブログ管理画面（/admin）を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,4 @@ BLOG_API_KEY=your_blog_api_key_here
 
 # Admin（ローカルのみ。Vercel には設定しない）
 ADMIN_ENABLED=
+NEXT_PUBLIC_ADMIN_ENABLED=

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # Blog API
 BLOG_API_KEY=your_blog_api_key_here
+
+# Admin（ローカルのみ。Vercel には設定しない）
+ADMIN_ENABLED=

--- a/src/app/admin/AdminClient.tsx
+++ b/src/app/admin/AdminClient.tsx
@@ -58,6 +58,8 @@ function Field({
 function ArticleForm({
   form,
   setForm,
+  tagsInput,
+  setTagsInput,
   onSubmit,
   onCancel,
   submitLabel,
@@ -66,6 +68,8 @@ function ArticleForm({
 }: {
   form: ArticleInput;
   setForm: (f: ArticleInput) => void;
+  tagsInput: string;
+  setTagsInput: (v: string) => void;
   onSubmit: () => void;
   onCancel: () => void;
   submitLabel: string;
@@ -102,16 +106,8 @@ function ArticleForm({
         <input
           className={inputCls}
           placeholder="例: SEO, マーケティング, Web制作"
-          value={form.tagNames.join(", ")}
-          onChange={(e) =>
-            setForm({
-              ...form,
-              tagNames: e.target.value
-                .split(",")
-                .map((t) => t.trim())
-                .filter(Boolean),
-            })
-          }
+          value={tagsInput}
+          onChange={(e) => setTagsInput(e.target.value)}
         />
       </Field>
 
@@ -198,6 +194,7 @@ export default function AdminClient({
   const [view, setView] = useState<View>("list");
   const [articles, setArticles] = useState(initialArticles);
   const [form, setForm] = useState<ArticleInput>(EMPTY_FORM);
+  const [tagsInput, setTagsInput] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -207,8 +204,16 @@ export default function AdminClient({
     if (res.ok) setArticles(await res.json());
   }
 
+  function parseTagsInput(): string[] {
+    return tagsInput
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
   function handleCreate() {
     setForm(EMPTY_FORM);
+    setTagsInput("");
     setEditingId(null);
     setError(null);
     setView("create");
@@ -217,7 +222,7 @@ export default function AdminClient({
   function handleSubmitCreate() {
     startTransition(async () => {
       try {
-        await createArticle(form);
+        await createArticle({ ...form, tagNames: parseTagsInput() });
         await refreshList();
         setView("list");
       } catch (e) {
@@ -230,6 +235,7 @@ export default function AdminClient({
     setError(null);
     const article = await getAdminArticleById(id);
     if (!article) return;
+    const tags = article.tagNames ?? [];
     setForm({
       title: article.title,
       slug: article.slug,
@@ -238,8 +244,9 @@ export default function AdminClient({
       category: article.category ?? "",
       status: article.status as "draft" | "published",
       published_at: article.published_at ?? null,
-      tagNames: article.tagNames ?? [],
+      tagNames: tags,
     });
+    setTagsInput(tags.join(", "));
     setEditingId(id);
     setView("edit");
   }
@@ -248,7 +255,7 @@ export default function AdminClient({
     if (!editingId) return;
     startTransition(async () => {
       try {
-        await updateArticle(editingId, form);
+        await updateArticle(editingId, { ...form, tagNames: parseTagsInput() });
         await refreshList();
         setView("list");
       } catch (e) {
@@ -357,6 +364,8 @@ export default function AdminClient({
             <ArticleForm
               form={form}
               setForm={setForm}
+              tagsInput={tagsInput}
+              setTagsInput={setTagsInput}
               onSubmit={handleSubmitCreate}
               onCancel={() => setView("list")}
               submitLabel="作成する"
@@ -373,6 +382,8 @@ export default function AdminClient({
             <ArticleForm
               form={form}
               setForm={setForm}
+              tagsInput={tagsInput}
+              setTagsInput={setTagsInput}
               onSubmit={handleSubmitEdit}
               onCancel={() => setView("list")}
               submitLabel="更新する"

--- a/src/app/admin/AdminClient.tsx
+++ b/src/app/admin/AdminClient.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  type ArticleInput,
+  createArticle,
+  deleteArticle,
+  getAdminArticleById,
+  updateArticle,
+} from "./actions";
+
+type Article = {
+  id: string;
+  title: string;
+  slug: string;
+  category: string;
+  status: string;
+  published_at: string | null;
+  updated_at: string;
+};
+
+type View = "list" | "create" | "edit";
+
+const EMPTY_FORM: ArticleInput = {
+  title: "",
+  slug: "",
+  excerpt: "",
+  content: "",
+  category: "",
+  status: "draft",
+  published_at: null,
+};
+
+export default function AdminClient({
+  initialArticles,
+}: {
+  initialArticles: Article[];
+}) {
+  const [view, setView] = useState<View>("list");
+  const [articles, setArticles] = useState(initialArticles);
+  const [form, setForm] = useState<ArticleInput>(EMPTY_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // ─── 一覧を再取得（Server Action 後） ─────────────────────
+  async function refreshList() {
+    const res = await fetch("/api/admin/articles");
+    if (res.ok) {
+      const data = await res.json();
+      setArticles(data);
+    }
+  }
+
+  // ─── 作成 ─────────────────────────────────────────────────
+  function handleCreate() {
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+    setError(null);
+    setView("create");
+  }
+
+  function handleSubmitCreate() {
+    startTransition(async () => {
+      try {
+        await createArticle(form);
+        await refreshList();
+        setView("list");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "作成に失敗しました");
+      }
+    });
+  }
+
+  // ─── 編集 ─────────────────────────────────────────────────
+  async function handleEdit(id: string) {
+    setError(null);
+    const article = await getAdminArticleById(id);
+    if (!article) return;
+    setForm({
+      title: article.title,
+      slug: article.slug,
+      excerpt: article.excerpt ?? "",
+      content: article.content ?? "",
+      category: article.category ?? "",
+      status: article.status as "draft" | "published",
+      published_at: article.published_at ?? null,
+    });
+    setEditingId(id);
+    setView("edit");
+  }
+
+  function handleSubmitEdit() {
+    if (!editingId) return;
+    startTransition(async () => {
+      try {
+        await updateArticle(editingId, form);
+        await refreshList();
+        setView("list");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "更新に失敗しました");
+      }
+    });
+  }
+
+  // ─── 削除 ─────────────────────────────────────────────────
+  function handleDelete(id: string, title: string) {
+    if (!window.confirm(`「${title}」を削除しますか？`)) return;
+    startTransition(async () => {
+      try {
+        await deleteArticle(id);
+        setArticles((prev) => prev.filter((a) => a.id !== id));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "削除に失敗しました");
+      }
+    });
+  }
+
+  // ─── フォーム共通 ──────────────────────────────────────────
+  function Field({
+    label,
+    children,
+  }: {
+    label: string;
+    children: React.ReactNode;
+  }) {
+    return (
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-gray-700">{label}</p>
+        {children}
+      </div>
+    );
+  }
+
+  const inputCls =
+    "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400";
+
+  function ArticleForm({
+    onSubmit,
+    submitLabel,
+  }: {
+    onSubmit: () => void;
+    submitLabel: string;
+  }) {
+    return (
+      <div className="space-y-5">
+        <Field label="タイトル">
+          <input
+            className={inputCls}
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+          />
+        </Field>
+        <Field label="スラッグ">
+          <input
+            className={inputCls}
+            value={form.slug}
+            onChange={(e) => setForm({ ...form, slug: e.target.value })}
+          />
+        </Field>
+        <Field label="カテゴリ">
+          <input
+            className={inputCls}
+            value={form.category}
+            onChange={(e) => setForm({ ...form, category: e.target.value })}
+          />
+        </Field>
+        <Field label="概要">
+          <textarea
+            className={`${inputCls} resize-none`}
+            rows={2}
+            value={form.excerpt}
+            onChange={(e) => setForm({ ...form, excerpt: e.target.value })}
+          />
+        </Field>
+        <Field label="本文（Markdown）">
+          <textarea
+            className={`${inputCls} resize-y font-mono text-xs`}
+            rows={16}
+            value={form.content}
+            onChange={(e) => setForm({ ...form, content: e.target.value })}
+          />
+        </Field>
+        <div className="flex gap-4">
+          <Field label="ステータス">
+            <select
+              className={inputCls}
+              value={form.status}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  status: e.target.value as "draft" | "published",
+                })
+              }
+            >
+              <option value="draft">下書き</option>
+              <option value="published">公開</option>
+            </select>
+          </Field>
+          <Field label="公開日時">
+            <input
+              type="datetime-local"
+              className={inputCls}
+              value={form.published_at?.slice(0, 16) ?? ""}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  published_at: e.target.value
+                    ? new Date(e.target.value).toISOString()
+                    : null,
+                })
+              }
+            />
+          </Field>
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex gap-3 pt-2">
+          <Button
+            onClick={onSubmit}
+            disabled={isPending}
+            className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-5 py-2 h-auto text-sm"
+          >
+            {isPending ? "保存中…" : submitLabel}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => setView("list")}
+            className="rounded-lg h-auto text-sm"
+          >
+            キャンセル
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── 描画 ──────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b px-6 py-4 flex items-center justify-between">
+        <div>
+          <p className="text-xs font-bold tracking-[0.2em] text-sky-600 uppercase">
+            Local Only
+          </p>
+          <h1 className="text-xl font-bold text-gray-900">ブログ管理</h1>
+        </div>
+        {view === "list" && (
+          <Button
+            onClick={handleCreate}
+            className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-4 py-2 h-auto text-sm"
+          >
+            + 新規作成
+          </Button>
+        )}
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-10">
+        {/* ─── 一覧 ─── */}
+        {view === "list" && (
+          <div className="space-y-3">
+            {articles.length === 0 && (
+              <p className="text-sm text-gray-400 text-center py-20">
+                記事がありません
+              </p>
+            )}
+            {articles.map((a) => (
+              <div
+                key={a.id}
+                className="bg-white rounded-xl border border-gray-200 px-5 py-4 flex items-center gap-4"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-gray-900 truncate">
+                    {a.title}
+                  </p>
+                  <div className="flex items-center gap-2 mt-1 flex-wrap">
+                    <Badge
+                      className={`text-xs ${
+                        a.status === "published"
+                          ? "bg-sky-50 text-sky-700 border-sky-200"
+                          : "bg-gray-100 text-gray-500 border-gray-200"
+                      } border`}
+                    >
+                      {a.status === "published" ? "公開" : "下書き"}
+                    </Badge>
+                    {a.category && (
+                      <span className="text-xs text-gray-400">
+                        {a.category}
+                      </span>
+                    )}
+                    {a.published_at && (
+                      <span className="text-xs text-gray-400">
+                        {new Date(a.published_at).toLocaleDateString("ja-JP")}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <Button
+                    variant="outline"
+                    onClick={() => handleEdit(a.id)}
+                    className="h-auto py-1.5 px-3 text-xs rounded-lg"
+                  >
+                    編集
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDelete(a.id, a.title)}
+                    disabled={isPending}
+                    className="h-auto py-1.5 px-3 text-xs rounded-lg text-red-600 border-red-200 hover:bg-red-50"
+                  >
+                    削除
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* ─── 作成 ─── */}
+        {view === "create" && (
+          <div>
+            <h2 className="text-lg font-bold text-gray-900 mb-6">新規作成</h2>
+            <ArticleForm onSubmit={handleSubmitCreate} submitLabel="作成する" />
+          </div>
+        )}
+
+        {/* ─── 編集 ─── */}
+        {view === "edit" && (
+          <div>
+            <h2 className="text-lg font-bold text-gray-900 mb-6">記事を編集</h2>
+            <ArticleForm onSubmit={handleSubmitEdit} submitLabel="更新する" />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/AdminClient.tsx
+++ b/src/app/admin/AdminClient.tsx
@@ -31,8 +31,165 @@ const EMPTY_FORM: ArticleInput = {
   category: "",
   status: "draft",
   published_at: null,
+  tagNames: [],
 };
 
+// ─── inputCls ────────────────────────────────────────────────────────────────
+const inputCls =
+  "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400";
+
+// ─── Field（コンポーネント外に定義してフォーカス問題を回避） ──────────────────
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-gray-700">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+// ─── ArticleForm（コンポーネント外に定義） ────────────────────────────────────
+function ArticleForm({
+  form,
+  setForm,
+  onSubmit,
+  onCancel,
+  submitLabel,
+  isPending,
+  error,
+}: {
+  form: ArticleInput;
+  setForm: (f: ArticleInput) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  submitLabel: string;
+  isPending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="space-y-5">
+      <Field label="タイトル *">
+        <input
+          className={inputCls}
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+      </Field>
+
+      <Field label="スラッグ *">
+        <input
+          className={inputCls}
+          value={form.slug}
+          onChange={(e) => setForm({ ...form, slug: e.target.value })}
+        />
+      </Field>
+
+      <Field label="カテゴリ *">
+        <input
+          className={inputCls}
+          value={form.category}
+          onChange={(e) => setForm({ ...form, category: e.target.value })}
+        />
+      </Field>
+
+      <Field label="タグ（カンマ区切り）">
+        <input
+          className={inputCls}
+          placeholder="例: SEO, マーケティング, Web制作"
+          value={form.tagNames.join(", ")}
+          onChange={(e) =>
+            setForm({
+              ...form,
+              tagNames: e.target.value
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean),
+            })
+          }
+        />
+      </Field>
+
+      <Field label="概要 *">
+        <textarea
+          className={`${inputCls} resize-none`}
+          rows={2}
+          value={form.excerpt}
+          onChange={(e) => setForm({ ...form, excerpt: e.target.value })}
+        />
+      </Field>
+
+      <Field label="本文（Markdown） *">
+        <textarea
+          className={`${inputCls} resize-y font-mono text-xs`}
+          rows={16}
+          value={form.content}
+          onChange={(e) => setForm({ ...form, content: e.target.value })}
+        />
+      </Field>
+
+      <div className="flex gap-4">
+        <Field label="ステータス">
+          <select
+            className={inputCls}
+            value={form.status}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                status: e.target.value as "draft" | "published",
+              })
+            }
+          >
+            <option value="draft">下書き</option>
+            <option value="published">公開</option>
+          </select>
+        </Field>
+
+        <Field label="公開日時">
+          <input
+            type="datetime-local"
+            className={inputCls}
+            value={form.published_at?.slice(0, 16) ?? ""}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                published_at: e.target.value
+                  ? new Date(e.target.value).toISOString()
+                  : null,
+              })
+            }
+          />
+        </Field>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          onClick={onSubmit}
+          disabled={isPending}
+          className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-5 py-2 h-auto text-sm"
+        >
+          {isPending ? "保存中…" : submitLabel}
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          className="rounded-lg h-auto text-sm"
+        >
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── AdminClient ──────────────────────────────────────────────────────────────
 export default function AdminClient({
   initialArticles,
 }: {
@@ -45,16 +202,11 @@ export default function AdminClient({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  // ─── 一覧を再取得（Server Action 後） ─────────────────────
   async function refreshList() {
     const res = await fetch("/api/admin/articles");
-    if (res.ok) {
-      const data = await res.json();
-      setArticles(data);
-    }
+    if (res.ok) setArticles(await res.json());
   }
 
-  // ─── 作成 ─────────────────────────────────────────────────
   function handleCreate() {
     setForm(EMPTY_FORM);
     setEditingId(null);
@@ -74,7 +226,6 @@ export default function AdminClient({
     });
   }
 
-  // ─── 編集 ─────────────────────────────────────────────────
   async function handleEdit(id: string) {
     setError(null);
     const article = await getAdminArticleById(id);
@@ -87,6 +238,7 @@ export default function AdminClient({
       category: article.category ?? "",
       status: article.status as "draft" | "published",
       published_at: article.published_at ?? null,
+      tagNames: article.tagNames ?? [],
     });
     setEditingId(id);
     setView("edit");
@@ -105,7 +257,6 @@ export default function AdminClient({
     });
   }
 
-  // ─── 削除 ─────────────────────────────────────────────────
   function handleDelete(id: string, title: string) {
     if (!window.confirm(`「${title}」を削除しますか？`)) return;
     startTransition(async () => {
@@ -118,127 +269,6 @@ export default function AdminClient({
     });
   }
 
-  // ─── フォーム共通 ──────────────────────────────────────────
-  function Field({
-    label,
-    children,
-  }: {
-    label: string;
-    children: React.ReactNode;
-  }) {
-    return (
-      <div className="space-y-1">
-        <p className="text-sm font-medium text-gray-700">{label}</p>
-        {children}
-      </div>
-    );
-  }
-
-  const inputCls =
-    "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400";
-
-  function ArticleForm({
-    onSubmit,
-    submitLabel,
-  }: {
-    onSubmit: () => void;
-    submitLabel: string;
-  }) {
-    return (
-      <div className="space-y-5">
-        <Field label="タイトル">
-          <input
-            className={inputCls}
-            value={form.title}
-            onChange={(e) => setForm({ ...form, title: e.target.value })}
-          />
-        </Field>
-        <Field label="スラッグ">
-          <input
-            className={inputCls}
-            value={form.slug}
-            onChange={(e) => setForm({ ...form, slug: e.target.value })}
-          />
-        </Field>
-        <Field label="カテゴリ">
-          <input
-            className={inputCls}
-            value={form.category}
-            onChange={(e) => setForm({ ...form, category: e.target.value })}
-          />
-        </Field>
-        <Field label="概要">
-          <textarea
-            className={`${inputCls} resize-none`}
-            rows={2}
-            value={form.excerpt}
-            onChange={(e) => setForm({ ...form, excerpt: e.target.value })}
-          />
-        </Field>
-        <Field label="本文（Markdown）">
-          <textarea
-            className={`${inputCls} resize-y font-mono text-xs`}
-            rows={16}
-            value={form.content}
-            onChange={(e) => setForm({ ...form, content: e.target.value })}
-          />
-        </Field>
-        <div className="flex gap-4">
-          <Field label="ステータス">
-            <select
-              className={inputCls}
-              value={form.status}
-              onChange={(e) =>
-                setForm({
-                  ...form,
-                  status: e.target.value as "draft" | "published",
-                })
-              }
-            >
-              <option value="draft">下書き</option>
-              <option value="published">公開</option>
-            </select>
-          </Field>
-          <Field label="公開日時">
-            <input
-              type="datetime-local"
-              className={inputCls}
-              value={form.published_at?.slice(0, 16) ?? ""}
-              onChange={(e) =>
-                setForm({
-                  ...form,
-                  published_at: e.target.value
-                    ? new Date(e.target.value).toISOString()
-                    : null,
-                })
-              }
-            />
-          </Field>
-        </div>
-
-        {error && <p className="text-sm text-red-600">{error}</p>}
-
-        <div className="flex gap-3 pt-2">
-          <Button
-            onClick={onSubmit}
-            disabled={isPending}
-            className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-5 py-2 h-auto text-sm"
-          >
-            {isPending ? "保存中…" : submitLabel}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => setView("list")}
-            className="rounded-lg h-auto text-sm"
-          >
-            キャンセル
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  // ─── 描画 ──────────────────────────────────────────────────
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b px-6 py-4 flex items-center justify-between">
@@ -259,7 +289,7 @@ export default function AdminClient({
       </header>
 
       <main className="max-w-4xl mx-auto px-6 py-10">
-        {/* ─── 一覧 ─── */}
+        {/* 一覧 */}
         {view === "list" && (
           <div className="space-y-3">
             {articles.length === 0 && (
@@ -278,11 +308,11 @@ export default function AdminClient({
                   </p>
                   <div className="flex items-center gap-2 mt-1 flex-wrap">
                     <Badge
-                      className={`text-xs ${
+                      className={`text-xs border ${
                         a.status === "published"
                           ? "bg-sky-50 text-sky-700 border-sky-200"
                           : "bg-gray-100 text-gray-500 border-gray-200"
-                      } border`}
+                      }`}
                     >
                       {a.status === "published" ? "公開" : "下書き"}
                     </Badge>
@@ -320,19 +350,35 @@ export default function AdminClient({
           </div>
         )}
 
-        {/* ─── 作成 ─── */}
+        {/* 作成 */}
         {view === "create" && (
           <div>
             <h2 className="text-lg font-bold text-gray-900 mb-6">新規作成</h2>
-            <ArticleForm onSubmit={handleSubmitCreate} submitLabel="作成する" />
+            <ArticleForm
+              form={form}
+              setForm={setForm}
+              onSubmit={handleSubmitCreate}
+              onCancel={() => setView("list")}
+              submitLabel="作成する"
+              isPending={isPending}
+              error={error}
+            />
           </div>
         )}
 
-        {/* ─── 編集 ─── */}
+        {/* 編集 */}
         {view === "edit" && (
           <div>
             <h2 className="text-lg font-bold text-gray-900 mb-6">記事を編集</h2>
-            <ArticleForm onSubmit={handleSubmitEdit} submitLabel="更新する" />
+            <ArticleForm
+              form={form}
+              setForm={setForm}
+              onSubmit={handleSubmitEdit}
+              onCancel={() => setView("list")}
+              submitLabel="更新する"
+              isPending={isPending}
+              error={error}
+            />
           </div>
         )}
       </main>

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export type ArticleInput = {
+  title: string;
+  slug: string;
+  excerpt: string;
+  content: string;
+  category: string;
+  status: "draft" | "published";
+  published_at: string | null;
+};
+
+export async function createArticle(input: ArticleInput) {
+  const supabase = createServiceClient();
+  const { error } = await supabase.from("articles").insert([input]);
+  if (error) throw new Error(error.message);
+  revalidatePath("/admin");
+  revalidatePath("/knowledge");
+}
+
+export async function updateArticle(id: string, input: ArticleInput) {
+  const supabase = createServiceClient();
+  const { error } = await supabase
+    .from("articles")
+    .update({ ...input, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/admin");
+  revalidatePath("/knowledge");
+}
+
+export async function deleteArticle(id: string) {
+  const supabase = createServiceClient();
+  const { error } = await supabase.from("articles").delete().eq("id", id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/admin");
+  revalidatePath("/knowledge");
+}
+
+export async function getAdminArticles() {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("articles")
+    .select("id, title, slug, category, status, published_at, updated_at")
+    .order("updated_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function getAdminArticleById(id: string) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("articles")
+    .select("*")
+    .eq("id", id)
+    .single();
+  if (error) return null;
+  return data;
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -11,23 +11,71 @@ export type ArticleInput = {
   category: string;
   status: "draft" | "published";
   published_at: string | null;
+  tagNames: string[];
 };
+
+// タグを upsert して ID を返す
+async function upsertTags(
+  supabase: ReturnType<typeof createServiceClient>,
+  names: string[],
+): Promise<string[]> {
+  if (names.length === 0) return [];
+  const { data, error } = await supabase
+    .from("tags")
+    .upsert(
+      names.map((name) => ({ name })),
+      { onConflict: "name" },
+    )
+    .select("id");
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((t) => t.id);
+}
+
+// article_tags を洗い替え
+async function syncArticleTags(
+  supabase: ReturnType<typeof createServiceClient>,
+  articleId: string,
+  tagIds: string[],
+) {
+  await supabase.from("article_tags").delete().eq("article_id", articleId);
+  if (tagIds.length === 0) return;
+  const { error } = await supabase
+    .from("article_tags")
+    .insert(tagIds.map((tag_id) => ({ article_id: articleId, tag_id })));
+  if (error) throw new Error(error.message);
+}
 
 export async function createArticle(input: ArticleInput) {
   const supabase = createServiceClient();
-  const { error } = await supabase.from("articles").insert([input]);
+  const { tagNames, ...articleData } = input;
+
+  const { data, error } = await supabase
+    .from("articles")
+    .insert([articleData])
+    .select("id")
+    .single();
   if (error) throw new Error(error.message);
+
+  const tagIds = await upsertTags(supabase, tagNames);
+  await syncArticleTags(supabase, data.id, tagIds);
+
   revalidatePath("/admin");
   revalidatePath("/knowledge");
 }
 
 export async function updateArticle(id: string, input: ArticleInput) {
   const supabase = createServiceClient();
+  const { tagNames, ...articleData } = input;
+
   const { error } = await supabase
     .from("articles")
-    .update({ ...input, updated_at: new Date().toISOString() })
+    .update({ ...articleData, updated_at: new Date().toISOString() })
     .eq("id", id);
   if (error) throw new Error(error.message);
+
+  const tagIds = await upsertTags(supabase, tagNames);
+  await syncArticleTags(supabase, id, tagIds);
+
   revalidatePath("/admin");
   revalidatePath("/knowledge");
 }
@@ -54,9 +102,14 @@ export async function getAdminArticleById(id: string) {
   const supabase = createServiceClient();
   const { data, error } = await supabase
     .from("articles")
-    .select("*")
+    .select("*, article_tags(tags(id, name))")
     .eq("id", id)
     .single();
   if (error) return null;
-  return data;
+
+  const tagNames = (data.article_tags ?? [])
+    .map((at: { tags: { name: string } | null }) => at.tags?.name)
+    .filter(Boolean) as string[];
+
+  return { ...data, tagNames };
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from "next/navigation";
+import AdminClient from "./AdminClient";
+import { getAdminArticles } from "./actions";
+
+export default async function AdminPage() {
+  if (!process.env.ADMIN_ENABLED) {
+    notFound();
+  }
+
+  const articles = await getAdminArticles();
+
+  return <AdminClient initialArticles={articles} />;
+}

--- a/src/app/api/admin/articles/route.ts
+++ b/src/app/api/admin/articles/route.ts
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+import { NextResponse } from "next/server";
+import { getAdminArticles } from "@/app/admin/actions";
+
+export async function GET() {
+  if (!process.env.ADMIN_ENABLED) {
+    notFound();
+  }
+  const articles = await getAdminArticles();
+  return NextResponse.json(articles);
+}

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -17,14 +17,14 @@ export function generateStaticParams() {
   return [];
 }
 
-// Markdownの見出し（## / ###）を抽出してToCを生成
+// Markdownの見出し（#）を抽出してToCを生成
 function extractHeadings(markdown: string) {
   const lines = markdown.split("\n");
   return lines
-    .filter((line) => /^#{2,3}\s/.test(line))
+    .filter((line) => /^#\s/.test(line))
     .map((line) => {
-      const level = line.match(/^(#{2,3})/)?.[1].length ?? 2;
-      const text = line.replace(/^#{2,3}\s+/, "").trim();
+      const level = 1;
+      const text = line.replace(/^#\s+/, "").trim();
       const id = text
         .toLowerCase()
         .replace(/[^\w\u3040-\u30FF\u4E00-\u9FFF\u3400-\u4DBF]/g, "-")
@@ -124,21 +124,18 @@ export default async function ArticlePage({ params }: Props) {
             className="mb-10 rounded-xl border border-gray-200 bg-gray-50 px-6 py-5"
           >
             <p className="text-sm font-bold text-gray-700 mb-3">目次</p>
-            <ol className="space-y-2">
-              {headings.map((h, i) => (
-                <li key={h.id} className={h.level === 3 ? "pl-4" : ""}>
+            <ul className="space-y-2">
+              {headings.map((h) => (
+                <li key={h.id}>
                   <a
                     href={`#${h.id}`}
-                    className="text-sm text-sky-600 hover:text-sky-800 hover:underline transition-colors flex gap-2"
+                    className="text-sm text-sky-600 hover:text-sky-800 hover:underline transition-colors"
                   >
-                    <span className="text-gray-400 shrink-0 tabular-nums">
-                      {i + 1}.
-                    </span>
                     {h.text}
                   </a>
                 </li>
               ))}
-            </ol>
+            </ul>
           </nav>
         )}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,6 +56,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   </Link>
                 </li>
               ))}
+              {process.env.NEXT_PUBLIC_ADMIN_ENABLED && (
+                <li>
+                  <Link
+                    href="/admin"
+                    className="text-xs font-medium text-gray-400 border border-gray-200 rounded-md px-2.5 py-1.5 hover:border-sky-400 hover:text-sky-600 transition-colors duration-200"
+                  >
+                    記事編集
+                  </Link>
+                </li>
+              )}
             </ul>
 
             {/* モバイル用ハンバーガー */}

--- a/src/lib/supabase/service.ts
+++ b/src/lib/supabase/service.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/supabase";
+
+// Service Role クライアント（RLS バイパス・サーバーサイド専用）
+// cookies 不要のため generateStaticParams やサーバーアクションでも使用可能
+export function createServiceClient() {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+    process.env.SUPABASE_SERVICE_ROLE_KEY as string,
+  );
+}


### PR DESCRIPTION
## Summary

- `ADMIN_ENABLED=true`（`.env.local` のみに設定）がない場合は `/admin` が 404 を返す
- Supabase service role client（RLS バイパス）で記事の CRUD を実行
- 記事一覧・作成・編集・削除を1ページで完結する管理 UI

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `src/app/admin/page.tsx` | Server Component・ADMIN_ENABLED ガード |
| `src/app/admin/AdminClient.tsx` | クライアント UI（一覧・作成・編集・削除） |
| `src/app/admin/actions.ts` | Server Actions（CRUD） |
| `src/app/api/admin/articles/route.ts` | 一覧再取得用 API Route |
| `src/lib/supabase/service.ts` | cookies 不要のサービスロールクライアント |

## ローカルでの確認方法

1. `.env.local` に `ADMIN_ENABLED=true` を追加
2. `npm run dev` → `http://localhost:3000/admin`

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)