### PR TITLE
fix: マーキーアニメーションをインラインスタイルに変更（dev環境対応）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -633,8 +633,17 @@ export default function Home() {
           </div>
 
           {/* Marquee */}
-          <div className="relative overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
-            <div className="flex gap-6 w-max animate-marquee hover:[animation-play-state:paused]">
+          <div
+            className="relative overflow-hidden"
+            style={{
+              maskImage:
+                "linear-gradient(to right, transparent, black 10%, black 90%, transparent)",
+            }}
+          >
+            <div
+              className="flex gap-6 w-max"
+              style={{ animation: "marquee 50s linear infinite" }}
+            >
               {[
                 ...works.map((w) => ({ ...w, _key: `a-${w.title}` })),
                 ...works.map((w) => ({ ...w, _key: `b-${w.title}` })),


### PR DESCRIPTION
## 問題

Tailwind v4 + Turbopack（dev）の組み合わせで、`@layer utilities` に定義したカスタムアニメーションクラス（`animate-marquee`）が処理されず、ローカル環境でアニメーションが動かない。

- **本番（webpack）**: 正常動作
- **ローカル dev（Turbopack）**: アニメーションが効かない

## 対応

`animate-marquee` クラスと `hover:[animation-play-state:paused]` を廃止し、インライン `style` で `animation` を直接指定。

## Test plan

- [ ] ローカル dev サーバーで支援実績のマーキーアニメーションが動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)