### PR TITLE
fix: 詳細ページを force-dynamic にして本番 500 エラーを修正

### DIFF
--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -11,11 +11,10 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-// generateStaticParams でのビルド時 Supabase 接続を回避するため常に空配列を返す。
-// ページはリクエスト時にオンデマンドで SSR される。
-export function generateStaticParams() {
-  return [];
-}
+// ビルド時の Supabase 接続を回避しつつ、cookies() が使えるよう SSR を強制する。
+// generateStaticParams だけだと on-demand ISR（静的コンテキスト）になり
+// cookies() が例外になるため、force-dynamic で明示的に SSR に固定する。
+export const dynamic = "force-dynamic";
 
 // Markdownの見出し（## / ###）を抽出してToCを生成
 function extractHeadings(markdown: string) {


### PR DESCRIPTION
## Summary
- `export const dynamic = "force-dynamic"` を追加して SSR を強制
- `generateStaticParams` を削除（`force-dynamic` がビルド時 Supabase 接続も回避するため不要）

## 原因
`generateStaticParams` を定義すると Next.js はそのルートを「静的」扱いにする。  
未知スラッグへのリクエストは on-demand ISR（静的コンテキスト）として処理されるため、  
`createClient()` 内の `cookies()` が **"called outside a request scope"** で例外 → 500 になる。  
`next dev` では全ページが動的レンダリングされるためローカルでは再現しない。

## Test plan
- [ ] CI pass を確認
- [ ] 本番デプロイ後、`/knowledge/<slug>` にアクセスして 200 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)