### PR TITLE
fix: force-dynamic を再追加して新規記事の 500 エラーを修正

### DIFF
--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -13,11 +13,11 @@ type Props = {
   params: Promise<{ slug: string }>;
 };
 
-// generateStaticParams でのビルド時 Supabase 接続を回避するため常に空配列を返す。
-// ページはリクエスト時にオンデマンドで SSR される。
-export function generateStaticParams() {
-  return [];
-}
+// force-dynamic で SSR を強制する。
+// generateStaticParams を使うと on-demand ISR（静的コンテキスト）になり
+// cookies() が例外になるため、force-dynamic で明示的に SSR に固定する。
+// ビルド時の Supabase 接続もスキップされるため generateStaticParams は不要。
+export const dynamic = "force-dynamic";
 
 // Markdownの見出し（## / ###）を抽出してToCを生成
 function extractHeadings(markdown: string) {


### PR DESCRIPTION
## Summary
- `export const dynamic = "force-dynamic"` を再追加
- `generateStaticParams` を削除（`force-dynamic` でビルド時 Supabase 接続もスキップされるため不要）
- `rehype-raw` / `remark-footnotes` などの PR #100 の変更は維持

## 原因
PR #100 で `force-dynamic` が削除され `generateStaticParams` が復元されたことで問題が再発。

on-demand ISR（静的コンテキスト）では `cookies()` が例外になるため、キャッシュ済みの記事は問題ないが、**新規・未キャッシュの記事**（`test22` 等）へのアクセス時に 500 になっていた。

## Test plan
- [ ] CI pass を確認
- [ ] マージ・デプロイ後、`/knowledge/test22` にアクセスして 200 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)