### PR TITLE
perf: ブログ画像の読み込みを最適化

### DIFF
--- a/src/app/knowledge/KnowledgeClient.tsx
+++ b/src/app/knowledge/KnowledgeClient.tsx
@@ -136,6 +136,7 @@ export function KnowledgeClient({ articles }: { articles: Article[] }) {
                       src={article.thumbnail_url}
                       alt={article.title}
                       fill
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                       className="object-cover group-hover:scale-105 transition-transform duration-300"
                     />
                   ) : (

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -160,6 +160,25 @@ export default async function ArticlePage({ params }: Props) {
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkFootnotes as never]}
             rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}
+            components={{
+              img({ src, alt }) {
+                if (!src || typeof src !== "string") return null;
+                return (
+                  <span
+                    className="block relative w-full"
+                    style={{ aspectRatio: "16/9" }}
+                  >
+                    <Image
+                      src={src}
+                      alt={alt ?? ""}
+                      fill
+                      className="object-contain rounded-lg"
+                      loading="lazy"
+                    />
+                  </span>
+                );
+              },
+            }}
           >
             {article.content}
           </ReactMarkdown>


### PR DESCRIPTION
## Summary

- 一覧ページ（`KnowledgeClient.tsx`）: `<Image>` に `sizes` 属性を追加。グリッドレイアウト（1/2/4カラム）に合わせた適切なサイズの画像を配信するようになり、不要な大サイズ画像のダウンロードを回避
- 詳細ページ本文（`[slug]/page.tsx`）: `react-markdown` の `img` カスタムレンダラーを追加。プレーンな `<img>` タグの代わりに `next/image` を使用し、lazy loading・webp/avif 変換を適用

## Test plan

- [ ] `/knowledge` で画像カードが正しく表示されること
- [ ] `/knowledge/[slug]` で本文中の画像が表示されること（lazy loading 動作確認）
- [ ] DevTools > Network で画像サイズが最適化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)