### PR TITLE
chore: Supabase・Vercelの接続情報をルールファイルに集約

### DIFF
--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -2,8 +2,20 @@
 
 ## プロジェクト情報
 
-プロジェクト設定は `supabase/config.toml` を参照。
-接続情報（URL・キー）は `.env.local` を参照。
+| 項目 | 値 |
+|---|---|
+| Project Ref | `yjpbkeytzoyliozbzmhf` |
+| API URL | `https://yjpbkeytzoyliozbzmhf.supabase.co` |
+| Dashboard | https://supabase.com/dashboard/project/yjpbkeytzoyliozbzmhf |
+
+## 環境変数（`.env.local` に定義済み）
+
+| 変数名 | 用途 |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | API URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 公開用匿名キー（読み取り） |
+| `SUPABASE_SERVICE_ROLE_KEY` | サービスロールキー（RLS バイパス） |
+| `SUPABASE_DB_PASSWORD` | DB パスワード（CLI 用） |
 
 ## MCP Server
 

--- a/.claude/rules/vercel.md
+++ b/.claude/rules/vercel.md
@@ -1,0 +1,30 @@
+# Vercel ルール
+
+## プロジェクト情報
+
+| 項目 | 値 |
+|---|---|
+| Project ID | `prj_88Zqft7PGcGPm7CHWMyzQeW6BI24` |
+| Org ID | `team_1b1OAksYMWLhwZWVLFzYp4qe` |
+| Dashboard | https://vercel.com/yutas-projects-44633396/portfolio-2025 |
+
+## CI / デプロイ確認コマンド
+
+```bash
+# PR の CI ステータスと Vercel デプロイ確認
+gh pr checks <PR番号>
+
+# Vercel ビルドログ取得
+npx vercel inspect <deployment-id> --logs
+```
+
+## 環境変数の管理
+
+- 本番・プレビューの環境変数は Vercel Dashboard から設定する
+- ローカル専用の変数（`NEXT_PUBLIC_ADMIN_ENABLED` など）は Vercel に設定しない
+- `.env.example` が環境変数のテンプレート（実値は書かない）
+
+## ビルド確認の方針
+
+- `npm run build` はローカルでは不要（Vercel CI に任せる）
+- PR 作成後に `gh pr checks <PR番号>` で CI が通過したことを確認してからユーザーに報告する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ No test framework is configured.
 @.claude/rules/docs.md
 @.claude/rules/env.md
 @.claude/rules/supabase.md
+@.claude/rules/vercel.md
 @.claude/rules/worktree.md
 
 ## Key Conventions


### PR DESCRIPTION
## Summary
- `.claude/rules/supabase.md` にProject Ref・API URL・Dashboard URL・環境変数一覧を追記
- `.claude/rules/vercel.md` を新規作成（Project ID・Dashboard URL・CI確認コマンド）
- `CLAUDE.md` に `@.claude/rules/vercel.md` を追加

## 目的
Claude Code が Supabase・Vercel を扱う際に複数ファイルを探しに行かなくて済むよう、接続情報を各ルールファイルに集約。CLAUDE.md の `@` インポートにより自動でコンテキストに含まれる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)