### PR TITLE
feat: SEO基盤整備（タスク1-1〜1-5）

### DIFF
--- a/src/app/_components/Header.tsx
+++ b/src/app/_components/Header.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Menu, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+const DRAWER_LINKS = [
+  { label: "ホーム", href: "/" },
+  { label: "サービス", href: "/#services" },
+  { label: "実績", href: "/#works" },
+  { label: "ブログ", href: "/knowledge" },
+];
+
+export function Header() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <header className="w-full border-b bg-white/80 backdrop-blur-md sticky top-0 z-50">
+        <nav className="max-w-7xl mx-auto flex items-center py-4 px-4 md:py-6 md:px-6">
+          <Link
+            href="/"
+            className="font-[family-name:var(--font-zen-kaku)] font-bold text-base md:text-xl tracking-wide md:tracking-widest whitespace-nowrap shrink-0 bg-gradient-to-r from-sky-600 to-indigo-500 bg-clip-text text-transparent"
+          >
+            YSデベロップメント
+          </Link>
+
+          <ul className="hidden md:flex items-center gap-1 text-sm font-medium ml-auto">
+            <li>
+              <Link
+                href="/#services"
+                className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
+              >
+                サービス
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/#works"
+                className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
+              >
+                実績
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/knowledge"
+                className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
+              >
+                ブログ
+              </Link>
+            </li>
+            {process.env.NEXT_PUBLIC_ADMIN_ENABLED && (
+              <li>
+                <Link
+                  href="/admin"
+                  className="text-xs font-medium text-gray-400 border border-gray-200 rounded-md px-2.5 py-1.5 hover:border-sky-400 hover:text-sky-600 transition-colors duration-200"
+                >
+                  記事編集
+                </Link>
+              </li>
+            )}
+            <li>
+              <Link
+                href="/contact"
+                className="bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors duration-200 py-2 px-4"
+              >
+                お問い合わせ
+              </Link>
+            </li>
+          </ul>
+
+          <button
+            type="button"
+            onClick={() => setIsOpen(true)}
+            aria-label="メニューを開く"
+            className="md:hidden shrink-0 ml-auto p-1.5 text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            <Menu size={24} />
+          </button>
+        </nav>
+      </header>
+
+      <div
+        className={`fixed inset-0 z-[60] bg-white flex flex-col transition-opacity duration-300 md:hidden ${
+          isOpen
+            ? "opacity-100 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
+        }`}
+        aria-hidden={!isOpen}
+      >
+        <div className="flex justify-end px-6 pt-6 pb-2">
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            aria-label="メニューを閉じる"
+            className="p-1.5 text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            <X size={28} />
+          </button>
+        </div>
+
+        <nav className="flex-1 px-8 pt-8">
+          <ul>
+            {DRAWER_LINKS.map(({ label, href }) => (
+              <li key={href} className="border-b border-gray-100">
+                <Link
+                  href={href}
+                  onClick={() => setIsOpen(false)}
+                  className="block py-5 text-base font-medium text-gray-800 hover:text-sky-600 transition-colors duration-200"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="px-8 pb-12 space-y-3">
+          <Link
+            href="/contact"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center justify-center gap-2 w-full py-4 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors duration-200"
+          >
+            お問い合わせ
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -19,6 +20,50 @@ type Props = {
 // cookies() が例外になるため、force-dynamic で明示的に SSR に固定する。
 // ビルド時の Supabase 接続もスキップされるため generateStaticParams は不要。
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const article = await getArticleBySlug(slug);
+
+  if (!article) {
+    return { title: "記事が見つかりません" };
+  }
+
+  const description =
+    article.excerpt || article.content.slice(0, 120).replace(/\n/g, " ");
+  const ogImage = article.thumbnail_url
+    ? [
+        {
+          url: article.thumbnail_url,
+          width: 1200,
+          height: 630,
+          alt: article.title,
+        },
+      ]
+    : undefined;
+
+  return {
+    title: article.title,
+    description,
+    alternates: {
+      canonical: `/knowledge/${slug}`,
+    },
+    openGraph: {
+      title: article.title,
+      description,
+      url: `/knowledge/${slug}`,
+      type: "article",
+      publishedTime: article.published_at ?? undefined,
+      images: ogImage,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: article.title,
+      description,
+      images: ogImage?.map((img) => img.url),
+    },
+  };
+}
 
 // Markdownの見出し（## / ###）を抽出してToCを生成
 function extractHeadings(markdown: string) {

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -8,14 +8,14 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "ブログ",
   description:
-    "Web制作・AI活用・業務効率化に関する技術記事を発信しています。Next.js、Supabase、フリーランスのノウハウなど。",
+    "福祉×IT・AIをテーマに、現役エンジニア・社会福祉士が発信するブログ。福祉業界のDX・AI活用・業務効率化の実践知見を紹介します。",
   alternates: {
     canonical: "/knowledge",
   },
   openGraph: {
     title: "ブログ | YSデベロップメント",
     description:
-      "Web制作・AI活用・業務効率化に関する技術記事を発信しています。",
+      "福祉×IT・AIをテーマに、現役エンジニア・社会福祉士が発信するブログ。福祉業界のDX・AI活用の実践知見を紹介します。",
     url: "/knowledge",
     type: "website",
   },

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -1,8 +1,25 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { getPublishedArticles } from "@/lib/knowledge";
 import { KnowledgeClient } from "./KnowledgeClient";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "ブログ",
+  description:
+    "Web制作・AI活用・業務効率化に関する技術記事を発信しています。Next.js、Supabase、フリーランスのノウハウなど。",
+  alternates: {
+    canonical: "/knowledge",
+  },
+  openGraph: {
+    title: "ブログ | YSデベロップメント",
+    description:
+      "Web制作・AI活用・業務効率化に関する技術記事を発信しています。",
+    url: "/knowledge",
+    type: "website",
+  },
+};
 
 export default async function KnowledgePage() {
   const articles = await getPublishedArticles();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import type { Metadata } from "next";
 import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
 import type { ReactNode } from "react";
 import { Header } from "./_components/Header";
@@ -16,6 +17,16 @@ const zenKakuGothic = Zen_Kaku_Gothic_New({
   variable: "--font-zen-kaku",
   display: "swap",
 });
+
+export const metadata: Metadata = {
+  title: {
+    default: "YSデベロップメント",
+    template: "%s | YSデベロップメント",
+  },
+  description:
+    "Web制作・AI活用支援のフリーランスエンジニア。Next.js・Supabaseを使った高品質なWebサイト・業務効率化システムを提供します。",
+  metadataBase: new URL("https://www.ysdevelopment.jp"),
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,7 @@
-"use client";
-
 import "./globals.css";
-import { Menu, X } from "lucide-react";
 import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
-import Link from "next/link";
-import { type ReactNode, useState } from "react";
-
-// SP ドロワー（ホームを先頭に追加）
-const DRAWER_LINKS = [
-  { label: "ホーム", href: "/" },
-  { label: "サービス", href: "/#services" },
-  { label: "実績", href: "/#works" },
-  { label: "ブログ", href: "/knowledge" },
-];
+import type { ReactNode } from "react";
+import { Header } from "./_components/Header";
 
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
@@ -29,135 +18,14 @@ const zenKakuGothic = Zen_Kaku_Gothic_New({
 });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <html
       lang="ja"
       className={`${notoSansJP.variable} ${zenKakuGothic.variable}`}
     >
       <body className="min-h-screen flex flex-col bg-background text-foreground font-[family-name:var(--font-noto-sans-jp)]">
-        {/* ナビゲーション */}
-        <header className="w-full border-b bg-white/80 backdrop-blur-md sticky top-0 z-50">
-          <nav className="max-w-7xl mx-auto flex items-center py-4 px-4 md:py-6 md:px-6">
-            {/* ロゴ（クリックでトップへ） */}
-            <Link
-              href="/"
-              className="font-[family-name:var(--font-zen-kaku)] font-bold text-base md:text-xl tracking-wide md:tracking-widest whitespace-nowrap shrink-0 bg-gradient-to-r from-sky-600 to-indigo-500 bg-clip-text text-transparent"
-            >
-              YSデベロップメント
-            </Link>
-
-            {/* PC用ナビ */}
-            <ul className="hidden md:flex items-center gap-1 text-sm font-medium ml-auto">
-              <li>
-                <Link
-                  href="/#services"
-                  className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
-                >
-                  サービス
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/#works"
-                  className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
-                >
-                  実績
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/knowledge"
-                  className="hover:text-sky-600 transition-colors duration-200 py-2 px-3"
-                >
-                  ブログ
-                </Link>
-              </li>
-              {process.env.NEXT_PUBLIC_ADMIN_ENABLED && (
-                <li>
-                  <Link
-                    href="/admin"
-                    className="text-xs font-medium text-gray-400 border border-gray-200 rounded-md px-2.5 py-1.5 hover:border-sky-400 hover:text-sky-600 transition-colors duration-200"
-                  >
-                    記事編集
-                  </Link>
-                </li>
-              )}
-              <li>
-                <Link
-                  href="/contact"
-                  className="bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors duration-200 py-2 px-4"
-                >
-                  お問い合わせ
-                </Link>
-              </li>
-            </ul>
-
-            {/* SP用ハンバーガー */}
-            <button
-              type="button"
-              onClick={() => setIsOpen(true)}
-              aria-label="メニューを開く"
-              className="md:hidden shrink-0 ml-auto p-1.5 text-gray-700 hover:text-gray-900 transition-colors"
-            >
-              <Menu size={24} />
-            </button>
-          </nav>
-        </header>
-
-        {/* SP: 全画面ドロワー */}
-        <div
-          className={`fixed inset-0 z-[60] bg-white flex flex-col transition-opacity duration-300 md:hidden ${
-            isOpen
-              ? "opacity-100 pointer-events-auto"
-              : "opacity-0 pointer-events-none"
-          }`}
-          aria-hidden={!isOpen}
-        >
-          {/* 閉じるボタン */}
-          <div className="flex justify-end px-6 pt-6 pb-2">
-            <button
-              type="button"
-              onClick={() => setIsOpen(false)}
-              aria-label="メニューを閉じる"
-              className="p-1.5 text-gray-700 hover:text-gray-900 transition-colors"
-            >
-              <X size={28} />
-            </button>
-          </div>
-
-          {/* ナビリンク */}
-          <nav className="flex-1 px-8 pt-8">
-            <ul>
-              {DRAWER_LINKS.map(({ label, href }) => (
-                <li key={href} className="border-b border-gray-100">
-                  <Link
-                    href={href}
-                    onClick={() => setIsOpen(false)}
-                    className="block py-5 text-base font-medium text-gray-800 hover:text-sky-600 transition-colors duration-200"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </nav>
-
-          {/* 下部 CTA */}
-          <div className="px-8 pb-12 space-y-3">
-            <Link
-              href="/contact"
-              onClick={() => setIsOpen(false)}
-              className="flex items-center justify-center gap-2 w-full py-4 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors duration-200"
-            >
-              お問い合わせ
-            </Link>
-          </div>
-        </div>
-
+        <Header />
         <main className="w-full flex-1">{children}</main>
-
         <footer className="border-t py-8 bg-gray-50">
           <div className="max-w-7xl mx-auto px-4 md:px-6">
             <div className="text-center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     template: "%s | YSデベロップメント",
   },
   description:
-    "Web制作・AI活用支援のフリーランスエンジニア。Next.js・Supabaseを使った高品質なWebサイト・業務効率化システムを提供します。",
+    "福祉×IT・AIの視点で発信するフリーランスエンジニア。社会福祉士の資格と6年のエンジニア経験を活かし、福祉業界のDX・AI導入支援を行っています。",
   metadataBase: new URL("https://www.ysdevelopment.jp"),
 };
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,45 @@
+import type { MetadataRoute } from "next";
+import { getPublishedArticles } from "@/lib/knowledge";
+
+export const dynamic = "force-dynamic";
+
+const BASE_URL = "https://www.ysdevelopment.jp";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const articles = await getPublishedArticles();
+
+  const articleEntries: MetadataRoute.Sitemap = articles.map((article) => ({
+    url: `${BASE_URL}/knowledge/${article.slug}`,
+    lastModified: new Date(article.updated_at),
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/knowledge`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/service`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    ...articleEntries,
+  ];
+}


### PR DESCRIPTION
## 概要

`docs/design/seo-cta-tasks.md` のフェーズ1（SEO基盤整備）タスク1-1〜1-5を実装。

## 変更内容

### タスク1-1: `layout.tsx` を Server Component 化し `Header.tsx` を切り出す
- `layout.tsx` から `"use client"` を削除
- ナビゲーション（ハンバーガーメニュー・ドロワー）を `src/app/_components/Header.tsx`（Client Component）に移譲
- これにより Next.js の metadata API が有効化される

### タスク1-2: ルートのデフォルト metadata を追加
- `layout.tsx` に `export const metadata` を追加
- `title.template` で「記事タイトル | YSデベロップメント」形式を設定
- サイト全体の `description` と `metadataBase` を定義

### タスク1-3: 記事詳細ページに `generateMetadata` を追加
- `src/app/knowledge/[slug]/page.tsx` に `generateMetadata` 関数を追加
- 各記事の title・description・OGP（og:title, og:image, og:type=article）・Twitter Card・canonical を出力

### タスク1-4: ブログ一覧ページに `metadata` を追加
- `src/app/knowledge/page.tsx` に `export const metadata` を追加
- title「ブログ」→ template 適用で「ブログ | YSデベロップメント」になる

### タスク1-5: `sitemap.ts` を新規作成
- `src/app/sitemap.ts` を新規作成
- 全公開記事URLを動的に生成し `/sitemap.xml` として配信

## Test plan
- [ ] Vercel CI が通過していることを確認
- [ ] プレビュー環境で各ページの `<title>` タグが正しく出力されることを確認
- [ ] `/sitemap.xml` にアクセスし記事URLが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)