### PR TITLE
feat: 記事末尾にCTAセクションを追加（タスク2-1）

### DIFF
--- a/src/app/knowledge/[slug]/_components/ConsultationCta.tsx
+++ b/src/app/knowledge/[slug]/_components/ConsultationCta.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export function ConsultationCta() {
+  return (
+    <div className="mt-16 rounded-2xl bg-gradient-to-br from-sky-500 to-indigo-600 px-8 py-10 text-white text-center shadow-lg">
+      <p className="text-sm font-semibold tracking-widest uppercase opacity-80 mb-3">
+        Free Consultation
+      </p>
+      <h2 className="text-2xl md:text-3xl font-bold mb-4 leading-snug">
+        AI・ITの導入、一緒に考えます
+      </h2>
+      <p className="text-sm md:text-base opacity-90 mb-8 leading-relaxed max-w-md mx-auto">
+        「何から始めればいい？」「自社に合うか不安」——
+        現役エンジニアがあなたの状況に合わせて一緒に整理します。
+      </p>
+      <Link
+        href="/contact"
+        className="inline-block bg-white text-sky-600 font-bold text-sm px-8 py-3 rounded-full hover:bg-sky-50 transition-colors duration-200 shadow"
+      >
+        無料で相談する →
+      </Link>
+    </div>
+  );
+}

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -10,6 +10,7 @@ import remarkFootnotes from "remark-footnotes";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
 import { getArticleBySlug } from "@/lib/knowledge";
+import { ConsultationCta } from "./_components/ConsultationCta";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -225,8 +226,10 @@ export default async function ArticlePage({ params }: Props) {
           </ReactMarkdown>
         </div>
 
+        <ConsultationCta />
+
         {/* 戻るリンク */}
-        <div className="mt-16 pt-8 border-t">
+        <div className="mt-10 pt-8 border-t">
           <Link
             href="/knowledge"
             className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-sky-600 transition-colors"


### PR DESCRIPTION
## 概要

記事を読み終えたユーザーを `/contact` へ誘導するCTAセクションを追加。

## 変更内容

- `src/app/knowledge/[slug]/_components/ConsultationCta.tsx` を新規作成
  - sky→indigo グラデーション背景
  - 「AI・ITの導入、一緒に考えます」コピー
  - 「無料で相談する →」ボタンで `/contact` に遷移
- `src/app/knowledge/[slug]/page.tsx` — 記事本文直下に `<ConsultationCta />` を挿入

🤖 Generated with [Claude Code](https://claude.com/claude-code)