### PR TITLE
feat: ブログ一覧ページ末尾にCTAバナーを追加（タスク2-4）

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -51,6 +51,28 @@ export default async function KnowledgePage() {
       <div className="max-w-7xl mx-auto px-6 md:px-10 py-12">
         <KnowledgeClient articles={articles} />
       </div>
+
+      {/* ── CTAバナー ─────────────────────────────────────────── */}
+      <div className="bg-gray-900 text-white">
+        <div className="max-w-7xl mx-auto px-6 md:px-10 py-16 text-center">
+          <p className="text-sm font-semibold tracking-widest uppercase text-sky-400 mb-3">
+            Free Consultation
+          </p>
+          <h2 className="text-2xl md:text-3xl font-bold mb-4 leading-snug">
+            AI・ITの導入、一緒に考えます
+          </h2>
+          <p className="text-sm md:text-base text-gray-300 mb-8 leading-relaxed max-w-lg mx-auto">
+            「何から始めればいい？」「自社に合うか不安」——
+            現役エンジニアがあなたの状況に合わせて一緒に整理します。
+          </p>
+          <Link
+            href="/contact"
+            className="inline-block bg-sky-500 hover:bg-sky-400 text-white font-bold text-sm px-8 py-3 rounded-full transition-colors duration-200"
+          >
+            無料で相談する →
+          </Link>
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## 概要

ブログ一覧ページ最下部にCTAバナーを追加し、記事を読む前のユーザーにも相談の選択肢を提示する。

## 変更内容

- `src/app/knowledge/page.tsx` — ページ末尾にダークバックグラウンドのCTAバナーを追加
  - 「AI・ITの導入、一緒に考えます」コピー
  - 「無料で相談する →」ボタンで `/contact` に遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)