### PR TITLE
feat: コンタクトページの導線テキストを改善（タスク2-5）

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -38,13 +38,40 @@ export default function ContactPage() {
     <main className="w-full py-16 md:py-24 px-6">
       <div className="max-w-2xl mx-auto">
         <h1 className="text-3xl md:text-4xl font-bold mb-4 text-center">
-          Contact
+          無料相談・お問い合わせ
         </h1>
-        <p className="text-muted-foreground mb-10 text-lg text-center leading-relaxed">
-          お仕事のご相談やお問い合わせは
+        <p className="text-muted-foreground mb-6 text-lg text-center leading-relaxed">
+          AI導入・Web制作・IT活用に関するご相談は
           <br />
-          お気軽にどうぞ！
+          お気軽にどうぞ。
         </p>
+
+        {/* 安心バッジ */}
+        <div className="flex flex-wrap justify-center gap-3 mb-10">
+          {["初回相談 無料", "返信は通常24時間以内", "秘密厳守"].map(
+            (label) => (
+              <span
+                key={label}
+                className="inline-flex items-center gap-1.5 text-xs font-medium bg-sky-50 text-sky-700 border border-sky-200 rounded-full px-3 py-1.5"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-3.5 h-3.5 shrink-0"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                {label}
+              </span>
+            ),
+          )}
+        </div>
 
         {formState === "success" ? (
           <div className="text-center py-12">


### PR DESCRIPTION
## 概要

「お問い合わせ」という汎用文言を具体的なメッセージに変え、フォーム送信への心理的ハードルを下げる。

## 変更内容

- 見出し: 「Contact」→「無料相談・お問い合わせ」
- リード文: AI導入・Web制作・IT活用に絞ったコピーに変更
- 安心バッジを3つ追加:「初回相談 無料」「返信は通常24時間以内」「秘密厳守」

🤖 Generated with [Claude Code](https://claude.com/claude-code)