### PR TITLE
feat: 記事末尾に著者プロフィールカードを追加（タスク2-2）

### DIFF
--- a/src/app/knowledge/[slug]/_components/AuthorCard.tsx
+++ b/src/app/knowledge/[slug]/_components/AuthorCard.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+
+export function AuthorCard() {
+  return (
+    <div className="mt-16 flex items-center gap-4 rounded-2xl border border-gray-100 bg-gray-50 px-6 py-5">
+      <div className="relative w-14 h-14 shrink-0 rounded-full overflow-hidden bg-gradient-to-br from-sky-100 to-indigo-100">
+        <Image
+          src="/images/profile.png"
+          alt="清水 優太"
+          fill
+          className="object-cover"
+        />
+      </div>
+      <div>
+        <p className="text-xs text-gray-400 mb-0.5">この記事を書いた人</p>
+        <p className="text-sm font-bold text-gray-900">清水 優太</p>
+        <p className="text-xs text-gray-500 leading-relaxed mt-1">
+          社会福祉士 / フリーランスエンジニア（歴6年）。
+          福祉×IT・AIを軸に、中小企業向けのAI導入支援・Web制作を行っています。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -10,6 +10,7 @@ import remarkFootnotes from "remark-footnotes";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
 import { getArticleBySlug } from "@/lib/knowledge";
+import { AuthorCard } from "./_components/AuthorCard";
 import { ConsultationCta } from "./_components/ConsultationCta";
 
 type Props = {
@@ -226,6 +227,7 @@ export default async function ArticlePage({ params }: Props) {
           </ReactMarkdown>
         </div>
 
+        <AuthorCard />
         <ConsultationCta />
 
         {/* 戻るリンク */}


### PR DESCRIPTION
## 概要

「誰が書いたか」を明示し、CTAへの信頼感を高める著者カードを追加。

## 変更内容

- `src/app/knowledge/[slug]/_components/AuthorCard.tsx` を新規作成
  - プロフィール画像（`/images/profile.png`）
  - 著者名: 清水 優太
  - 肩書: 社会福祉士 / フリーランスエンジニア（歴6年）
  - 一言紹介
- CTA（ConsultationCta）の直上に配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)