### PR TITLE
feat: GA4 を導入（タスク3-1）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 # Blog API
 BLOG_API_KEY=your_blog_api_key_here
 
+# Google Analytics 4
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+
 # Admin（ローカルのみ。Vercel には設定しない）
 ADMIN_ENABLED=
 NEXT_PUBLIC_ADMIN_ENABLED=

--- a/src/app/_components/GoogleAnalytics.tsx
+++ b/src/app/_components/GoogleAnalytics.tsx
@@ -1,0 +1,23 @@
+import Script from "next/script";
+
+export function GoogleAnalytics() {
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  if (!gaId) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gaId}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
 import type { ReactNode } from "react";
+import { GoogleAnalytics } from "./_components/GoogleAnalytics";
 import { Header } from "./_components/Header";
 
 const notoSansJP = Noto_Sans_JP({
@@ -35,6 +36,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${notoSansJP.variable} ${zenKakuGothic.variable}`}
     >
       <body className="min-h-screen flex flex-col bg-background text-foreground font-[family-name:var(--font-noto-sans-jp)]">
+        <GoogleAnalytics />
         <Header />
         <main className="w-full flex-1">{children}</main>
         <footer className="border-t py-8 bg-gray-50">


### PR DESCRIPTION
## 概要

GA4 によるアクセス計測基盤を追加。

## 変更内容

- `src/app/_components/GoogleAnalytics.tsx` を新規作成
  - `next/script` の `afterInteractive` で gtag.js を非同期読み込み
  - `NEXT_PUBLIC_GA_ID` が未設定の場合は何も描画しない（ローカル開発に影響なし）
- `src/app/layout.tsx` — `<GoogleAnalytics />` を追加
- `.env.example` — `NEXT_PUBLIC_GA_ID` を追記

## マージ後の作業（手動）

Vercel の環境変数に以下を追加してください：

| 変数名 | 値 |
|---|---|
| `NEXT_PUBLIC_GA_ID` | `G-W6S9RGX10S` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)