### PR TITLE
fix: GA4 実装を @next/third-parties/google に切り替え

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfoliio",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.2.4",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-navigation-menu": "^1.2.14",
@@ -877,6 +878,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.4.tgz",
+      "integrity": "sha512-FhDDX02cAr0WIo3la+QHP3XaAAV6twCfFk/y8pHikFT8MHwNpB3XgEdaT0omLrIWBORhM5wkbbUJFq+pBqZzmw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -5138,6 +5152,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "biome format --write"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-navigation-menu": "^1.2.14",

--- a/src/app/_components/GoogleAnalytics.tsx
+++ b/src/app/_components/GoogleAnalytics.tsx
@@ -1,23 +1,8 @@
-import Script from "next/script";
+import { GoogleAnalytics as GA } from "@next/third-parties/google";
 
 export function GoogleAnalytics() {
   const gaId = process.env.NEXT_PUBLIC_GA_ID;
   if (!gaId) return null;
 
-  return (
-    <>
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${gaId}');
-        `}
-      </Script>
-    </>
-  );
+  return <GA gaId={gaId} />;
 }


### PR DESCRIPTION
## 問題

手動実装（`next/script` + inline gtag）では `window.gtag` 関数が実行されず、
GA4 にデータが送信されていなかった。

## 修正

`@next/third-parties/google` の `GoogleAnalytics` コンポーネントに差し替え。
Next.js 公式推奨の実装で、確実に gtag が動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)