### PR TITLE
chore: output/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,7 @@ next-env.d.ts
 
 /tmp/*
 
+# output
+/output/
 
 /.playwright-mcp/*


### PR DESCRIPTION
## Summary
- `output/` ディレクトリを `.gitignore` に追加
- `output/gyas.co.jp` などのビルド成果物をGit追跡対象外にする

## Test plan
- [ ] `.gitignore` に `/output/` が含まれていることを確認