### PR TITLE
fix: @next/third-parties を Next.js 15 系に揃えて GA を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "portfoliio",
       "version": "0.1.0",
       "dependencies": {
-        "@next/third-parties": "^16.2.4",
+        "@next/third-parties": "^15.5.14",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-navigation-menu": "^1.2.14",
@@ -881,15 +881,15 @@
       }
     },
     "node_modules/@next/third-parties": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.4.tgz",
-      "integrity": "sha512-FhDDX02cAr0WIo3la+QHP3XaAAV6twCfFk/y8pHikFT8MHwNpB3XgEdaT0omLrIWBORhM5wkbbUJFq+pBqZzmw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.5.18.tgz",
+      "integrity": "sha512-Kp51CbeHgYelpkasFI1gAeAeMPfMTctLcmVIfE2MiRRfC6oYbR3+lO4S0NbNRppOZ7RkbB5P6uW/qOewxth6iA==",
       "license": "MIT",
       "dependencies": {
         "third-party-capital": "1.0.20"
       },
       "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "biome format --write"
   },
   "dependencies": {
-    "@next/third-parties": "^16.2.4",
+    "@next/third-parties": "^15.5.14",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-navigation-menu": "^1.2.14",


### PR DESCRIPTION
## Summary

- `@next/third-parties@^16.2.4`（Next.js 16 用）を `^15.5.14` にダウングレード
- `next@^15.5.14` と揃えることで GA 初期化インラインスクリプトの SyntaxError を解消
- `window.gtag` が undefined になる問題が修正され、GA4 へのデータ送信が再開される

## 根本原因

`@next/third-parties` は Next.js のメジャーバージョンに揃える必要がある。v16 系を Next.js 15 で使うと、内部の Script 注入処理で `SyntaxError: Failed to execute 'appendChild' on 'Node': Invalid or unexpected token` が発生。これにより GA 初期化の `gtag('config', ...)` が呼ばれず、Google Analytics にデータが届かない状態になっていた。

## Test plan

- [ ] Vercel CI が通過することを確認
- [ ] プレビュー URL でブラウザコンソール `typeof window.gtag` が `"function"` になることを確認
- [ ] SyntaxError がコンソールから消えていることを確認
- [ ] Google Analytics リアルタイムレポートでアクセスが計上されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)