### PR TITLE
fix: GA_ID の末尾改行を .trim() で除去し SyntaxError を修正

### DIFF
--- a/src/app/_components/GoogleAnalytics.tsx
+++ b/src/app/_components/GoogleAnalytics.tsx
@@ -1,7 +1,7 @@
 import { GoogleAnalytics as GA } from "@next/third-parties/google";
 
 export function GoogleAnalytics() {
-  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  const gaId = process.env.NEXT_PUBLIC_GA_ID?.trim();
   if (!gaId) return null;
 
   return <GA gaId={gaId} />;


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_GA_ID?.trim()` を追加（`src/app/_components/GoogleAnalytics.tsx`）
- Vercel 環境変数 `NEXT_PUBLIC_GA_ID` (Production) の末尾改行を削除して再登録済み

## 根本原因

Vercel に設定された `NEXT_PUBLIC_GA_ID` の値に末尾の改行文字（`\n`）が混入していた。これが `@next/third-parties` の生成するインライン init スクリプトに補間され、次のような壊れた JS が生成されていた：

```js
gtag('config', 'G-W6S9RGX10S
'   // ← 改行でシングルクォート文字列が切れる → SyntaxError
```

PR #127・#128・#132 でいずれも修正を試みたが、実装方式に関わらず同じ原因で全て失敗していた。

## Test plan

- [ ] Vercel CI が通過することを確認
- [ ] マージ後の本番サイトで `typeof window.gtag === "function"` を確認
- [ ] `SyntaxError: Failed to execute 'appendChild' on 'Node'` がコンソールから消えることを確認
- [ ] Google Analytics のリアルタイムレポートにアクセスが計上されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)