### PR TITLE
feat: 記事APIを堅牢化しGET/PATCHを追加

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath, revalidateTag } from "next/cache";
+import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
 import { createServiceClient } from "@/lib/supabase/service";
 
 export type ArticleInput = {
@@ -14,37 +15,6 @@ export type ArticleInput = {
   tagNames: string[];
   thumbnail_url: string | null;
 };
-
-// タグを upsert して ID を返す
-async function upsertTags(
-  supabase: ReturnType<typeof createServiceClient>,
-  names: string[],
-): Promise<string[]> {
-  if (names.length === 0) return [];
-  const { data, error } = await supabase
-    .from("tags")
-    .upsert(
-      names.map((name) => ({ name })),
-      { onConflict: "name" },
-    )
-    .select("id");
-  if (error) throw new Error(error.message);
-  return (data ?? []).map((t) => t.id);
-}
-
-// article_tags を洗い替え
-async function syncArticleTags(
-  supabase: ReturnType<typeof createServiceClient>,
-  articleId: string,
-  tagIds: string[],
-) {
-  await supabase.from("article_tags").delete().eq("article_id", articleId);
-  if (tagIds.length === 0) return;
-  const { error } = await supabase
-    .from("article_tags")
-    .insert(tagIds.map((tag_id) => ({ article_id: articleId, tag_id })));
-  if (error) throw new Error(error.message);
-}
 
 export async function createArticle(input: ArticleInput) {
   const supabase = createServiceClient();

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,47 +1,149 @@
-import { createClient } from "@supabase/supabase-js";
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
-import type { Database } from "@/types/supabase";
+import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
+import { createServiceClient } from "@/lib/supabase/service";
 
-function createServiceClient() {
-  return createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.SUPABASE_SERVICE_ROLE_KEY as string,
-  );
-}
+// AI から書き込める記事フィールドの allowlist。
+// status / published_at を意図的に含めていない：公開操作は人間のみが行うため、
+// リクエストに何が入っていても公開ステータスへ遷移できない構造にしている。
+const WRITABLE_FIELDS = [
+  "title",
+  "slug",
+  "content",
+  "excerpt",
+  "category",
+  "thumbnail_url",
+] as const;
+
+// thumbnail_url のみ nullable。他は DB 側が NOT NULL
+type ArticleFields = {
+  title?: string;
+  slug?: string;
+  content?: string;
+  excerpt?: string;
+  category?: string;
+  thumbnail_url?: string | null;
+};
+
+type RequiredField = "title" | "slug" | "content" | "excerpt" | "category";
+
+const REQUIRED_ON_CREATE: RequiredField[] = [
+  "title",
+  "slug",
+  "content",
+  "excerpt",
+  "category",
+];
 
 function authenticate(request: Request): boolean {
   const auth = request.headers.get("Authorization");
-  if (!auth?.startsWith("Bearer ")) return false;
-  return auth.slice(7) === process.env.BLOG_API_KEY;
+  const key = process.env.BLOG_API_KEY;
+  if (!key || !auth?.startsWith("Bearer ")) return false;
+  return auth.slice(7) === key;
 }
 
-export async function POST(request: Request) {
-  if (!authenticate(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+// allowlist に無いキー（status / published_at 等）は黙って捨てる
+function pickWritable(body: Record<string, unknown>): ArticleFields {
+  const picked: ArticleFields = {};
+  for (const field of WRITABLE_FIELDS) {
+    const value = body[field];
+    if (value === undefined) continue;
+    if (field === "thumbnail_url") {
+      // 明示的な null はサムネイル削除の意思表示として通す
+      if (value === null || typeof value === "string") {
+        picked.thumbnail_url = value;
+      }
+      continue;
+    }
+    if (typeof value === "string") {
+      picked[field] = value;
+    }
+  }
+  return picked;
+}
+
+function normalizeTags(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter(
+    (t): t is string => typeof t === "string" && t.length > 0,
+  );
+}
+
+type RowWithTags = {
+  article_tags?: { tags: { id: string; name: string } | null }[] | null;
+};
+
+function flattenTags<T extends RowWithTags>(row: T) {
+  const { article_tags, ...rest } = row;
+  return {
+    ...rest,
+    tags: (article_tags ?? [])
+      .map((at) => at.tags)
+      .filter((t): t is { id: string; name: string } => t !== null),
+  };
+}
+
+// GET /api/articles          → 全 status の一覧（重複チェック用）
+// GET /api/articles?slug=xxx → 本文を含む単一記事（旧版退避用）
+export async function GET(request: Request) {
+  if (!authenticate(request)) return unauthorized();
+
+  const slug = new URL(request.url).searchParams.get("slug");
+  const supabase = createServiceClient();
+
+  if (slug) {
+    const { data, error } = await supabase
+      .from("articles")
+      .select("*, article_tags(tags(id, name))")
+      .eq("slug", slug)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    if (!data) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json({ article: flattenTags(data) });
   }
 
-  const body = await request.json();
-  const {
-    title,
-    slug,
-    content,
-    excerpt,
-    category,
-    tags,
-    status,
-    published_at,
-  } = body;
+  const { data, error } = await supabase
+    .from("articles")
+    .select(
+      "id, title, slug, category, status, published_at, updated_at, article_tags(tags(id, name))",
+    )
+    .order("updated_at", { ascending: false });
 
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ articles: (data ?? []).map(flattenTags) });
+}
+
+// POST /api/articles → draft として新規作成（公開はしない）
+export async function POST(request: Request) {
+  if (!authenticate(request)) return unauthorized();
+
+  const body = (await request.json()) as Record<string, unknown>;
+  const fields = pickWritable(body);
+
+  const missing = REQUIRED_ON_CREATE.filter((f) => !fields[f]);
+  const { title, slug, content, excerpt, category } = fields;
   if (!title || !slug || !content || !excerpt || !category) {
     return NextResponse.json(
-      { error: "必須項目が不足しています" },
+      { error: `必須項目が不足しています: ${missing.join(", ")}` },
       { status: 400 },
     );
   }
 
   const supabase = createServiceClient();
 
-  const { data: article, error: articleError } = await supabase
+  const { data: article, error } = await supabase
     .from("articles")
     .insert({
       title,
@@ -49,31 +151,114 @@ export async function POST(request: Request) {
       content,
       excerpt,
       category,
-      status: status ?? "draft",
-      published_at: published_at ?? null,
+      thumbnail_url: fields.thumbnail_url ?? null,
+      // 常に draft。リクエストの status / published_at は反映しない
+      status: "draft",
+      published_at: null,
     })
-    .select("id")
+    .select("id, slug")
     .single();
 
-  if (articleError) {
-    return NextResponse.json({ error: articleError.message }, { status: 500 });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  if (Array.isArray(tags) && tags.length > 0) {
-    for (const tagName of tags) {
-      const { data: tag } = await supabase
-        .from("tags")
-        .upsert({ name: tagName }, { onConflict: "name" })
-        .select("id")
-        .single();
+  const tags = normalizeTags(body.tags);
+  if (tags && tags.length > 0) {
+    const tagIds = await upsertTags(supabase, tags);
+    await syncArticleTags(supabase, article.id, tagIds);
+  }
 
-      if (tag) {
-        await supabase
-          .from("article_tags")
-          .insert({ article_id: article.id, tag_id: tag.id });
-      }
+  revalidateTag("published-articles");
+
+  return NextResponse.json(
+    { id: article.id, slug: article.slug, status: "draft" },
+    { status: 201 },
+  );
+}
+
+// PATCH /api/articles → 既存記事の更新。status / published_at は変更できない
+export async function PATCH(request: Request) {
+  if (!authenticate(request)) return unauthorized();
+
+  const body = (await request.json()) as Record<string, unknown>;
+  const slug = typeof body.slug === "string" ? body.slug : null;
+  const id = typeof body.id === "string" ? body.id : null;
+
+  if (!slug && !id) {
+    return NextResponse.json(
+      { error: "slug または id を指定してください" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServiceClient();
+
+  // 更新前のスナップショットを取得して返す（旧版退避の突き合わせ用）
+  const baseQuery = supabase
+    .from("articles")
+    .select("*, article_tags(tags(id, name))");
+  const { data: previous, error: previousError } = await (id
+    ? baseQuery.eq("id", id)
+    : baseQuery.eq("slug", slug as string)
+  ).maybeSingle();
+
+  if (previousError) {
+    return NextResponse.json({ error: previousError.message }, { status: 500 });
+  }
+  if (!previous) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const fields = pickWritable(body);
+
+  // slug をキーに更新する場合、slug 自体の変更は id 指定を必須にする
+  // （変更後の slug で対象を引けなくなり、意図しない記事を更新する恐れがあるため）
+  if (!id && fields.slug && fields.slug !== previous.slug) {
+    return NextResponse.json(
+      { error: "slug を変更する場合は id を指定してください" },
+      { status: 400 },
+    );
+  }
+
+  // slug は対象の指定にも使われるため、現行値と同じなら書き込み対象から外す。
+  // 外さないと「実質何も変えない PATCH」が updated_at だけを更新してしまい、
+  // リライト候補の除外判定（直近30日以内の更新）を誤らせる。
+  if (fields.slug === previous.slug) {
+    delete fields.slug;
+  }
+
+  const tags = normalizeTags(body.tags);
+
+  if (Object.keys(fields).length === 0 && !tags) {
+    return NextResponse.json(
+      { error: "更新可能な項目が指定されていません" },
+      { status: 400 },
+    );
+  }
+
+  if (Object.keys(fields).length > 0) {
+    const { error } = await supabase
+      .from("articles")
+      .update({ ...fields, updated_at: new Date().toISOString() })
+      .eq("id", previous.id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
     }
   }
 
-  return NextResponse.json({ id: article.id }, { status: 201 });
+  if (tags) {
+    const tagIds = await upsertTags(supabase, tags);
+    await syncArticleTags(supabase, previous.id, tagIds);
+  }
+
+  revalidateTag("published-articles");
+
+  return NextResponse.json({
+    id: previous.id,
+    slug: fields.slug ?? previous.slug,
+    // status は更新対象外。現行値をそのまま返す
+    status: previous.status,
+    previous: flattenTags(previous),
+  });
 }

--- a/src/lib/knowledge/write.ts
+++ b/src/lib/knowledge/write.ts
@@ -1,0 +1,34 @@
+import type { createServiceClient } from "@/lib/supabase/service";
+
+type ServiceClient = ReturnType<typeof createServiceClient>;
+
+// タグを upsert して ID を返す
+export async function upsertTags(
+  supabase: ServiceClient,
+  names: string[],
+): Promise<string[]> {
+  if (names.length === 0) return [];
+  const { data, error } = await supabase
+    .from("tags")
+    .upsert(
+      names.map((name) => ({ name })),
+      { onConflict: "name" },
+    )
+    .select("id");
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((t) => t.id);
+}
+
+// article_tags を洗い替え
+export async function syncArticleTags(
+  supabase: ServiceClient,
+  articleId: string,
+  tagIds: string[],
+) {
+  await supabase.from("article_tags").delete().eq("article_id", articleId);
+  if (tagIds.length === 0) return;
+  const { error } = await supabase
+    .from("article_tags")
+    .insert(tagIds.map((tag_id) => ({ article_id: articleId, tag_id })));
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## やること

ブログAI運用パイプラインの **PR-B1**（トラックB：インフラ）。AIから記事を書き込む経路を `/api/articles` に一本化し、**公開・削除が構造的に不可能**な設計にする。

## なぜコードで縛るのか

要件定義書 §10 の受け入れ条件は「**どのような指示を与えても**、AIが公開ステータスへの変更・記事削除を実行しないこと」。規約（`.claude/rules/blog.md`）に書くだけでは宣言に過ぎず、指示次第で破られうる。そのためAPI層で構造的に潰した。

| 変更 | 効果 |
|---|---|
| 書き込みフィールドの **allowlist 化**（`status` / `published_at` を含めない） | リクエストに何を入れても公開状態へ遷移できない。公開記事を draft に戻すこともできない |
| `POST` は常に `status:"draft"`, `published_at:null` | 従来は `status ?? "draft"` だったため `"published"` を渡せば公開できてしまった |
| `DELETE` ハンドラを実装しない | 405。§7「DELETE禁止」をコードで保証 |

## その他の変更

- **`PATCH` を追加。** 更新前スナップショットを `previous` で返し、旧版退避ファイルと実データの一致を確認できるようにした
- **`GET` を追加。** 全status横断の一覧（重複チェック用）と、`?slug=` での本文込み単一記事取得（旧版退避用）
- **`upsertTags` / `syncArticleTags` を `src/lib/knowledge/write.ts` に抽出。** これらは `admin/actions.ts` 内の `"use server"` に閉じており Route Handler から使えなかった。挙動は変えずに共用化
- **`revalidateTag` を追加。** API経由の作成・更新がキャッシュを無効化しておらず、`revalidate: 86400` のため最大24時間サイトに反映されない既存バグがあった

## 実装中に見つけて直した不具合

`slug` は**対象の指定にも使う**ため、`PATCH {"slug":"...","status":"draft"}` のような実質no-opなリクエストで `slug` が書き込み対象に入り、「更新可能な項目なし」の400ガードをすり抜けて **`updated_at` だけを更新**していた。

これは単なる無駄書き込みではない。後続の `seo-analyst` は「直近30日以内に更新済みの記事はリライト候補から除外」する仕様のため、`updated_at` の誤更新は**記事をリライト対象から不当に除外**してしまう。現行値と同じ slug は書き込み対象から外すよう修正した。

## 検証（ローカル dev サーバー）

| ケース | 期待 | 結果 |
|---|---|---|
| 認証なし POST | 401 | ✅ 401 |
| `DELETE` | 405 | ✅ 405 |
| 必須項目なし POST | 400 | ✅ 400 |
| `status:"published"` を渡して POST | draft で保存 | ✅ `status=draft` / `published_at=null` |
| PATCH で draft を公開しようと試行 | 無視される | ✅ draft のまま |
| **PATCH で公開記事を draft に戻そうと試行** | 無視される | ✅ published のまま |
| PATCH の `previous` スナップショット | 返る | ✅ 返却を確認 |
| 実質no-opな PATCH | 400・`updated_at` 不変 | ✅ 修正後に確認 |
| PATCH で本文更新 | 200 | ✅ 反映を確認 |
| タグの upsert / 紐付け | 動作 | ✅ 確認 |

`biome check` / `tsc --noEmit` ともにクリーン。

## 対象ファイル

- `src/app/api/articles/route.ts`
- `src/lib/knowledge/write.ts`（新規）
- `src/app/admin/actions.ts`（ヘルパの import 化のみ。挙動は不変）

## 備考

検証で作成した draft 記事 `test-guard-rail` が残っています。§7 により AI では削除できないため、**お手数ですが `/admin` から削除をお願いします。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)