### PR TITLE
refactor: 問い合わせ先メールアドレスを環境変数化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # Resend (メール送信)
 # https://resend.com/api-keys
 RESEND_API_KEY=your_resend_api_key_here
+# 問い合わせフォームの送信先
+CONTACT_TO_EMAIL=your_email@example.com
 SUPABASE_DB_PASSWORD=
 
 # Supabase

--- a/docs/design/contact.md
+++ b/docs/design/contact.md
@@ -43,5 +43,7 @@
 ## メール送信
 
 - サービス: Resend
-- 送信先: shimizuyuta213@gmail.com
-- 環境変数: `RESEND_API_KEY`（Vercel の環境変数に設定）
+- 送信先: `CONTACT_TO_EMAIL` で指定（ソースには直書きしない）
+- 環境変数: `RESEND_API_KEY`・`CONTACT_TO_EMAIL`（いずれも Vercel の環境変数に設定）
+
+`CONTACT_TO_EMAIL` が未設定の場合は送信せず 500 を返す。

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,6 +3,7 @@ import { Resend } from "resend";
 
 export async function POST(request: Request) {
   const resend = new Resend(process.env.RESEND_API_KEY);
+  const contactTo = process.env.CONTACT_TO_EMAIL;
   const { name, email, message } = await request.json();
 
   if (!name || !email || !message) {
@@ -12,9 +13,14 @@ export async function POST(request: Request) {
     );
   }
 
+  if (!contactTo) {
+    console.error("CONTACT_TO_EMAIL が設定されていません");
+    return NextResponse.json({ error: "送信に失敗しました" }, { status: 500 });
+  }
+
   const { error } = await resend.emails.send({
     from: "Portfolio Contact <onboarding@resend.dev>",
-    to: "shimizuyuta213@gmail.com",
+    to: contactTo,
     replyTo: email,
     subject: `【お問い合わせ】${name}様より`,
     text: `名前: ${name}\nメール: ${email}\n\nメッセージ:\n${message}`,


### PR DESCRIPTION
## 概要

`src/app/api/contact/route.ts` に直書きされていた問い合わせ先メールアドレスを、環境変数 `CONTACT_TO_EMAIL` に移します。

リポジトリの個人情報スキャンで見つかりました。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/api/contact/route.ts` | `to:` を `process.env.CONTACT_TO_EMAIL` から取得。未設定時は 500 |
| `.env.example` | `CONTACT_TO_EMAIL` を追加 |
| `docs/design/contact.md` | 送信先の記述を環境変数ベースに更新 |

## なぜ

- **なぜ環境変数化するか** — パブリックリポジトリにメールアドレスが平文であると、スクレイパーによる収集対象になる。送信先は設定値であってコードではない
- **なぜ未設定時に 500 を返すか** — フォールバック先を用意すると、環境変数の設定漏れに気付かないまま意図しない宛先へ送信される。明示的に失敗させ、`console.error` でログに残す方が安全
- **なぜ `from:` はそのままか** — `onboarding@resend.dev` は Resend の共有送信元で、個人情報ではないため対象外

## ⚠️ マージ前に必要な作業

**Vercel の環境変数に `CONTACT_TO_EMAIL` を追加してください**（Production / Preview 両方）。未設定だと問い合わせフォームが 500 を返します。

## 確認

- [x] `npm run lint` — 46 files クリーン
- [x] `npx tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)