### PR TITLE
feat: draft 記事のプレビュー機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # Blog API
 BLOG_API_KEY=your_blog_api_key_here
+# 記事APIの接続先。プレビューURLの組み立てにも使う（例: http://localhost:3000）
+BLOG_API_BASE_URL=http://localhost:3000
+
+# draft プレビュー
+# /knowledge/<slug>?preview=<PREVIEW_TOKEN> で未公開記事を閲覧できる
+# 未設定・空の環境ではプレビュー機能は無効（draft は 404）
+PREVIEW_TOKEN=your_preview_token_here
 
 # Google Analytics 4
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/src/app/knowledge/[slug]/_components/PreviewBanner.tsx
+++ b/src/app/knowledge/[slug]/_components/PreviewBanner.tsx
@@ -1,0 +1,25 @@
+type Props = {
+  status: string;
+  publishedAt: string | null;
+};
+
+// 下書きプレビューであることを明示する帯。
+// 本番の公開記事と見間違えたまま確認を済ませてしまう事故を防ぐ。
+export function PreviewBanner({ status, publishedAt }: Props) {
+  const scheduled =
+    status === "published" &&
+    publishedAt !== null &&
+    new Date(publishedAt) > new Date();
+
+  return (
+    <div className="sticky top-0 z-50 border-b border-amber-300 bg-amber-100 px-4 py-2.5 text-center">
+      <p className="text-sm font-bold text-amber-900">
+        プレビュー表示（status: {status}
+        {scheduled ? " / 公開予約中" : ""}）
+      </p>
+      <p className="mt-0.5 text-xs text-amber-800">
+        このページは検索エンジンに登録されません。公開するには管理画面から操作してください。
+      </p>
+    </div>
+  );
+}

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -9,13 +9,35 @@ import rehypeSlug from "rehype-slug";
 import remarkFootnotes from "remark-footnotes";
 import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
-import { getArticleBySlug } from "@/lib/knowledge";
+import { getArticleBySlug, getArticleBySlugForPreview } from "@/lib/knowledge";
+import { isValidPreviewToken } from "@/lib/knowledge/preview";
 import { AuthorCard } from "./_components/AuthorCard";
 import { ConsultationCta } from "./_components/ConsultationCta";
+import { PreviewBanner } from "./_components/PreviewBanner";
 
 type Props = {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ preview?: string }>;
 };
+
+// ?preview=<PREVIEW_TOKEN> が正しいときだけ draft を取得する。
+// トークンが無効なら「プレビューではない」として扱い、通常どおり
+// 公開記事のみを探す。結果として draft は notFound() になり、
+// 「トークンが違う」と「記事が無い」を外から区別できない。
+// draft の存在自体を漏らさないための設計。
+async function resolveArticle(
+  slug: string,
+  searchParams: Promise<{ preview?: string }>,
+) {
+  const { preview } = await searchParams;
+  const isPreview = isValidPreviewToken(preview);
+
+  const article = isPreview
+    ? await getArticleBySlugForPreview(slug)
+    : await getArticleBySlug(slug);
+
+  return { article, isPreview };
+}
 
 // force-dynamic で SSR を強制する。
 // generateStaticParams を使うと on-demand ISR（静的コンテキスト）になり
@@ -23,12 +45,24 @@ type Props = {
 // ビルド時の Supabase 接続もスキップされるため generateStaticParams は不要。
 export const dynamic = "force-dynamic";
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: Props): Promise<Metadata> {
   const { slug } = await params;
-  const article = await getArticleBySlug(slug);
+  const { article, isPreview } = await resolveArticle(slug, searchParams);
 
   if (!article) {
     return { title: "記事が見つかりません" };
+  }
+
+  // プレビューは未公開の内容なので、検索エンジンに拾わせない。
+  // canonical も付けない（未公開URLを正規URLとして申告しないため）。
+  if (isPreview) {
+    return {
+      title: `[プレビュー] ${article.title}`,
+      robots: { index: false, follow: false },
+    };
   }
 
   const description =
@@ -84,9 +118,9 @@ function extractHeadings(markdown: string) {
     });
 }
 
-export default async function ArticlePage({ params }: Props) {
+export default async function ArticlePage({ params, searchParams }: Props) {
   const { slug } = await params;
-  const article = await getArticleBySlug(slug);
+  const { article, isPreview } = await resolveArticle(slug, searchParams);
 
   if (!article) {
     notFound();
@@ -103,6 +137,12 @@ export default async function ArticlePage({ params }: Props) {
 
   return (
     <div className="bg-white min-h-screen">
+      {isPreview && (
+        <PreviewBanner
+          status={article.status}
+          publishedAt={article.published_at}
+        />
+      )}
       {/* パンくずナビ */}
       <div className="border-b bg-gray-50">
         <nav

--- a/src/lib/knowledge/index.ts
+++ b/src/lib/knowledge/index.ts
@@ -16,6 +16,22 @@ export type Article = {
   tags: { id: string; name: string }[];
 };
 
+type ArticleRow = Omit<Article, "tags"> & {
+  thumbnail_url: string | null;
+  article_tags: { tags: { id: string; name: string } | null }[];
+};
+
+function toArticle(row: ArticleRow): Article {
+  return {
+    ...row,
+    thumbnail_url: row.thumbnail_url ?? null,
+    tags: row.article_tags.map((at) => at.tags).filter(Boolean) as {
+      id: string;
+      name: string;
+    }[],
+  };
+}
+
 export const getPublishedArticles = unstable_cache(
   async (limit?: number): Promise<Article[]> => {
     const supabase = createServiceClient();
@@ -35,13 +51,7 @@ export const getPublishedArticles = unstable_cache(
 
     if (error || !data) return [];
 
-    return data.map((row) => ({
-      ...row,
-      thumbnail_url: row.thumbnail_url ?? null,
-      tags: row.article_tags
-        .map((at: { tags: { id: string; name: string } | null }) => at.tags)
-        .filter(Boolean) as { id: string; name: string }[],
-    }));
+    return data.map(toArticle);
   },
   ["published-articles"],
   { revalidate: 86400, tags: ["published-articles"] },
@@ -60,14 +70,30 @@ export const getArticleBySlug = unstable_cache(
 
     if (error || !data) return undefined;
 
-    return {
-      ...data,
-      thumbnail_url: data.thumbnail_url ?? null,
-      tags: data.article_tags
-        .map((at: { tags: { id: string; name: string } | null }) => at.tags)
-        .filter(Boolean) as { id: string; name: string }[],
-    };
+    return toArticle(data);
   },
   ["article-by-slug"],
   { revalidate: 86400, tags: ["published-articles"] },
 );
+
+// プレビュー専用。status を絞らず、draft も予約投稿も取得する。
+//
+// unstable_cache で包んでいないのは意図的：
+// - draft は編集のたびに変わるため、毎回最新を取得する必要がある
+// - published-articles タグのキャッシュに混ぜると、公開記事向けの
+//   revalidateTag（人間が公開操作時に行う）の意味が濁る
+export async function getArticleBySlugForPreview(
+  slug: string,
+): Promise<Article | undefined> {
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("articles")
+    .select("*, article_tags(tags(id, name))")
+    .eq("slug", slug)
+    .single();
+
+  if (error || !data) return undefined;
+
+  return toArticle(data);
+}

--- a/src/lib/knowledge/preview.ts
+++ b/src/lib/knowledge/preview.ts
@@ -1,0 +1,20 @@
+import { timingSafeEqual } from "node:crypto";
+
+// プレビュートークンの照合。
+//
+// fail closed：PREVIEW_TOKEN が未設定・空文字の環境ではプレビュー機能ごと
+// 無効になる。設定漏れの環境で draft が誰でも見える事故を防ぐため。
+export function isValidPreviewToken(token: string | undefined): boolean {
+  const expected = process.env.PREVIEW_TOKEN?.trim();
+
+  if (!expected || !token) return false;
+
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+
+  // timingSafeEqual は長さが違うと例外を投げるので先に弾く。
+  // 長さの differences は秘匿できないが、内容の総当たりは時間差から守る。
+  if (a.length !== b.length) return false;
+
+  return timingSafeEqual(a, b);
+}


### PR DESCRIPTION
## 背景

`.claude/rules/blog.md` は draft 保存後に**プレビューURLの提示を義務づけ**、形式まで規定している：

```
{BLOG_API_BASE_URL}/knowledge/{slug}?preview={PREVIEW_TOKEN}
```

しかし**この仕組みは実装されていなかった**。`getArticleBySlug` が `.eq("status","published")` で絞るため draft は 404 になり、`PREVIEW_TOKEN` / `BLOG_API_BASE_URL` は `.env.example` にも無かった。ルールが存在しない機能を前提にしている状態で、このままでは執筆コマンド（`docs/記事.md` §6.3）の完了報告が成立しない。

`docs/記事.md` §8 のステップ1に着手する前提として先に実装する。

## 変更内容

| ファイル | 内容 |
|---|---|
| `src/lib/knowledge/index.ts` | `getArticleBySlugForPreview` を追加。行マッピングを `toArticle` に共通化 |
| `src/lib/knowledge/preview.ts` | トークン照合（新規） |
| `src/app/knowledge/[slug]/page.tsx` | `searchParams` 対応、noindex、プレビュー帯 |
| `src/app/knowledge/[slug]/_components/PreviewBanner.tsx` | 下書き表示中であることを示す帯（新規） |
| `.env.example` | `PREVIEW_TOKEN` / `BLOG_API_BASE_URL` を追記 |

## 設計判断

- **キャッシュしない** — draft は編集のたびに変わる。また `published-articles` タグのキャッシュに混ぜると、人間が公開時に行う `revalidateTag` の意味が濁る（§7 で AI が触れない領域）
- **fail closed** — `PREVIEW_TOKEN` 未設定・空の環境ではプレビュー機能ごと無効。設定漏れの環境で draft が誰でも見える事故を防ぐ
- **照合失敗は 404** — 「トークンが違う」と応答すると draft の存在自体が漏れるため、通常の404と区別できないようにした
- **`timingSafeEqual`** — トークン総当たりの時間差を潰す
- **noindex + canonical なし** — 未公開記事が検索結果に載る事故を防ぐ。未公開URLを正規URLとして申告しない

## 検証記録

- 検証者: Claude
- 内容: ローカル（:3100）で dev サーバーを起動し、`POST /api/articles` で実際に draft を作成して確認

| 検証項目 | 結果 |
|---|---|
| 正しいトークン | ✅ HTTP 200・プレビュー帯あり・noindex あり・本文描画あり |
| トークン無し | ✅ HTTP 404 |
| 誤ったトークン | ✅ HTTP 404 |
| 長さ一致の誤トークン | ✅ HTTP 404（長さ比較だけで通らないこと） |
| `PREVIEW_TOKEN` 未設定 + 正しかったトークン | ✅ HTTP 404（fail closed） |
| 既存の公開記事 | ✅ HTTP 200・noindex なし・プレビュー帯なし・canonical あり |
| 記事一覧ページ | ✅ HTTP 200 |
| ブラウザ実表示 | ✅ タイトルが `[プレビュー] ...` になることを確認 |
| `npm run lint` / `npx tsc --noEmit` | ✅ 両方パス |

- 結果: ✅ 問題なし
- 備考: 検証用 draft `zz-preview-verification` が残っている。§7 のガードレール（記事の DELETE 禁止）に従い、削除は人間に依頼する

## マージ後に必要な作業

**Vercel に `PREVIEW_TOKEN` の設定が必要**（Production / Preview）。未設定だと本番のプレビューURLは 404 のまま。値の生成はローカルで行い、登録は人間が行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)