### PR TITLE
fix: admin の Server Actions に認可チェックを追加

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -4,6 +4,18 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
 import { createServiceClient } from "@/lib/supabase/service";
 
+// "use server" のファイルでは export した関数がすべて Server Action として
+// 公開され、Next-Action ヘッダ付き POST で外部から直接呼び出せる。
+// ページ側（admin/page.tsx）の ADMIN_ENABLED チェックは呼び出し側のガードに
+// すぎず、アクション本体には掛からない。そのためアクションごとに検査する。
+//
+// export しないことでこの関数自体は Server Action にならない。
+function assertAdminEnabled() {
+  if (!process.env.ADMIN_ENABLED) {
+    throw new Error("Forbidden");
+  }
+}
+
 export type ArticleInput = {
   title: string;
   slug: string;
@@ -17,6 +29,7 @@ export type ArticleInput = {
 };
 
 export async function createArticle(input: ArticleInput) {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const { tagNames, ...articleData } = input;
 
@@ -41,6 +54,7 @@ export async function createArticle(input: ArticleInput) {
 }
 
 export async function updateArticle(id: string, input: ArticleInput) {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const { tagNames, ...articleData } = input;
 
@@ -64,6 +78,7 @@ export async function updateArticle(id: string, input: ArticleInput) {
 }
 
 export async function deleteArticle(id: string) {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const { error } = await supabase.from("articles").delete().eq("id", id);
   if (error) throw new Error(error.message);
@@ -73,6 +88,7 @@ export async function deleteArticle(id: string) {
 }
 
 export async function getAdminArticles() {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const { data, error } = await supabase
     .from("articles")
@@ -83,6 +99,7 @@ export async function getAdminArticles() {
 }
 
 export async function uploadThumbnail(formData: FormData): Promise<string> {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const file = formData.get("file") as File;
   const bytes = await file.arrayBuffer();
@@ -99,6 +116,7 @@ export async function uploadThumbnail(formData: FormData): Promise<string> {
 }
 
 export async function getAdminArticleById(id: string) {
+  assertAdminEnabled();
   const supabase = createServiceClient();
   const { data, error } = await supabase
     .from("articles")


### PR DESCRIPTION
## 背景

「一般の第三者が本番ドメインから記事を追加できるか」を調べる過程で見つけた。

`src/app/admin/actions.ts` の6つの関数は `"use server"` で公開されているが、**認証・認可のチェックが1行も無い**。`ADMIN_ENABLED` によるガードは `admin/page.tsx` と `api/admin/articles/route.ts` という**呼び出し側にしか無く、アクション本体には掛かっていない**。

Server Actions はビルド時に ID が振られ、`Next-Action` ヘッダ付き POST で直接呼び出せる。本番の Server Action ランタイムが有効であることは実測で確認した：

```
$ curl -X POST https://www.ysdevelopment.jp/ -H "Next-Action: 0000...0000"
HTTP 404  "Server action not found."
```

これは「そのIDが無い」という応答であり、**正しいIDなら実行される**ことを意味する。

## 影響範囲

| アクション | 悪用された場合 |
|---|---|
| `createArticle` / `updateArticle` | `status: "published"` を指定でき、**記事の公開まで可能** |
| `deleteArticle` | 記事の削除 |
| `getAdminArticles` / `getAdminArticleById` | **下書きの本文が読める** |
| `uploadThumbnail` | **公開ストレージへの無認証ファイルアップロード** |

`blog.md` がAIに「記事の DELETE 禁止」「公開は人間のみ」を課している一方、アプリ側にこの穴が開いている状態だった。

## 現時点で悪用可能とまでは確認していない

公開ページが参照する JS チャンク12個を調べた範囲では、管理アクションの痕跡は見つからなかった。アクションIDが外部から得られなければ到達できないため、**即座に悪用可能とは言えない**。

ただし現状の安全性は「IDが漏れていないこと」だけに依存しており、以下で崩れる：
- 将来 `ADMIN_ENABLED` を本番で有効にする
- admin 関連コードが公開ページのチャンクに混ざるリファクタが入る
- Next.js の更新でアクションIDの扱いが変わる

## 変更内容

`export` しない関数は Server Action にならない性質を使い、非公開のガードを定義して各アクションの先頭で呼ぶ。

```ts
function assertAdminEnabled() {
  if (!process.env.ADMIN_ENABLED) {
    throw new Error("Forbidden");
  }
}
```

対象は `createArticle` / `updateArticle` / `deleteArticle` / `getAdminArticles` / `uploadThumbnail` / `getAdminArticleById` の6つすべて。`/api/articles` の `authenticate()` と同じ fail closed の構造になる。

## 検証記録

- 検証者: Claude
- 内容:
  - `npm run lint` ✅ / `npx tsc --noEmit` ✅
  - `ADMIN_ENABLED=1` でローカル起動し `/admin` にアクセス → エラーが `Forbidden` ではなく `supabaseUrl is required`（`actions.ts:92` の `createServiceClient`）で停止。**ガードを通過して本体処理に到達しており、正規利用を壊していない**ことを確認（この worktree に `.env.local` を置いていないため Supabase 接続で落ちるのは想定どおり）
- 結果: ✅ 問題なし
- 備考: **「塞ぐ側」の実挙動は未検証。** 実際の Server Action ID を抽出して `ADMIN_ENABLED` 無しで POST を投げる検証を試みたが、環境変数へのアクセスがフックでブロックされたため到達できなかった。ガードは各関数の1行目で `throw` する単純な構造であり、コードレビューで担保されたい。マージ後、本番で `/admin` が引き続き 404 であること・公開記事に影響が無いことは確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)