### PR TITLE
feat: /admin の本文欄にライブプレビューを追加

### DIFF
--- a/src/app/admin/AdminClient.tsx
+++ b/src/app/admin/AdminClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useState, useTransition } from "react";
+import { ArticleBody } from "@/components/ArticleBody";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,6 +41,44 @@ const EMPTY_FORM: ArticleInput = {
 // ─── inputCls ────────────────────────────────────────────────────────────────
 const inputCls =
   "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400";
+
+// ─── 本文タブ ────────────────────────────────────────────────────────────────
+// shadcn の Tabs は未導入のため、依存を増やさず Button で組む。
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md px-3 py-1 text-xs transition-colors ${
+        active
+          ? "bg-sky-600 font-bold text-white"
+          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// blog.md が数値で規定している項目（見出し階層・文字数）を書きながら確認する。
+// h4 以下は規約で禁止のため、使われていたら警告する。
+function getOutline(content: string) {
+  const lines = content.split("\n");
+  return {
+    chars: content.length,
+    h2: lines.filter((l) => /^##\s/.test(l)).length,
+    h3: lines.filter((l) => /^###\s/.test(l)).length,
+    hasDeepHeading: lines.some((l) => /^#{4,}\s/.test(l)),
+  };
+}
 
 // ─── Field（コンポーネント外に定義してフォーカス問題を回避） ──────────────────
 function Field({
@@ -151,6 +190,10 @@ function ArticleForm({
     ? URL.createObjectURL(thumbnailFile)
     : (form.thumbnail_url ?? null);
 
+  // 本文欄のタブ（編集 / プレビュー）
+  const [contentTab, setContentTab] = useState<"edit" | "preview">("edit");
+  const outline = getOutline(form.content);
+
   return (
     <div className="space-y-5">
       <Field label="タイトル *">
@@ -236,12 +279,52 @@ function ArticleForm({
       </Field>
 
       <Field label="本文（Markdown） *">
-        <textarea
-          className={`${inputCls} resize-y font-mono text-xs`}
-          rows={16}
-          value={form.content}
-          onChange={(e) => setForm({ ...form, content: e.target.value })}
-        />
+        <div className="mb-2 flex items-center gap-1">
+          <TabButton
+            active={contentTab === "edit"}
+            onClick={() => setContentTab("edit")}
+          >
+            編集
+          </TabButton>
+          <TabButton
+            active={contentTab === "preview"}
+            onClick={() => setContentTab("preview")}
+          >
+            プレビュー
+          </TabButton>
+
+          {contentTab === "preview" && (
+            <span className="ml-auto flex items-center gap-3 text-xs text-gray-500">
+              <span>{outline.chars.toLocaleString()}字</span>
+              <span>h2: {outline.h2}</span>
+              <span>h3: {outline.h3}</span>
+              {outline.hasDeepHeading && (
+                <span className="font-bold text-red-600">
+                  h4以下あり（規約違反）
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+
+        {contentTab === "edit" ? (
+          <textarea
+            className={`${inputCls} resize-y font-mono text-xs`}
+            rows={16}
+            value={form.content}
+            onChange={(e) => setForm({ ...form, content: e.target.value })}
+          />
+        ) : (
+          <div className="min-h-[22rem] rounded-lg border border-gray-300 bg-white px-4 py-3">
+            {form.content.trim() ? (
+              <ArticleBody content={form.content} />
+            ) : (
+              <p className="text-sm text-gray-400">
+                本文を入力するとプレビューが表示されます
+              </p>
+            )}
+          </div>
+        )}
       </Field>
 
       <ImageUploader />

--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -2,12 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-import rehypeHighlight from "rehype-highlight";
-import rehypeRaw from "rehype-raw";
-import rehypeSlug from "rehype-slug";
-import remarkFootnotes from "remark-footnotes";
-import remarkGfm from "remark-gfm";
+import { ArticleBody } from "@/components/ArticleBody";
 import { Badge } from "@/components/ui/badge";
 import { getArticleBySlug, getArticleBySlugForPreview } from "@/lib/knowledge";
 import { isValidPreviewToken } from "@/lib/knowledge/preview";
@@ -239,33 +234,7 @@ export default async function ArticlePage({ params, searchParams }: Props) {
         )}
 
         {/* 記事本文 */}
-        <div className="prose prose-neutral prose-headings:font-bold prose-headings:text-gray-900 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded max-w-none">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkFootnotes as never]}
-            rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}
-            components={{
-              img({ src, alt }) {
-                if (!src || typeof src !== "string") return null;
-                return (
-                  <span
-                    className="block relative w-full"
-                    style={{ aspectRatio: "16/9" }}
-                  >
-                    <Image
-                      src={src}
-                      alt={alt ?? ""}
-                      fill
-                      className="object-contain rounded-lg"
-                      loading="lazy"
-                    />
-                  </span>
-                );
-              },
-            }}
-          >
-            {article.content}
-          </ReactMarkdown>
-        </div>
+        <ArticleBody content={article.content} />
 
         <AuthorCard />
         <ConsultationCta />

--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -1,0 +1,45 @@
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import rehypeSlug from "rehype-slug";
+import remarkFootnotes from "remark-footnotes";
+import remarkGfm from "remark-gfm";
+
+// 記事本文の描画。記事詳細ページと /admin のプレビューで共有する。
+// 別実装にすると必ず見た目がずれるため、必ずこのコンポーネントを通す。
+//
+// "use client" は付けない：記事詳細ページ（Server Component）では
+// サーバー描画のまま、AdminClient から import したときだけ
+// クライアントバンドルに含まれる。
+export function ArticleBody({ content }: { content: string }) {
+  return (
+    <div className="prose prose-neutral prose-headings:font-bold prose-headings:text-gray-900 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded max-w-none">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkFootnotes as never]}
+        rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}
+        components={{
+          img({ src, alt }) {
+            if (!src || typeof src !== "string") return null;
+            return (
+              <span
+                className="block relative w-full"
+                style={{ aspectRatio: "16/9" }}
+              >
+                <Image
+                  src={src}
+                  alt={alt ?? ""}
+                  fill
+                  className="object-contain rounded-lg"
+                  loading="lazy"
+                />
+              </span>
+            );
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}


### PR DESCRIPTION
## やること

`/admin` の記事編集画面で、書いている Markdown の描画結果を保存せずに確認できるようにする。

## 背景

本文欄は素の `<textarea>` のみで、**保存して記事ページを開くまで描画結果が分からなかった**。見出し階層の崩れ・テーブルの記法ミス・コードブロックの閉じ忘れが後から発覚する。

保存済み draft を本番同等の見た目で見る手段は #141 で実装済み（`/knowledge/<slug>?preview=<token>`）。本PRが埋めるのは「**保存前に、書きながら確認する**」ギャップ。

## 実装

| ファイル | 変更 |
|---|---|
| `src/components/ArticleBody.tsx` | 新規。本文描画を共通化 |
| `src/app/knowledge/[slug]/page.tsx` | 該当ブロックを `<ArticleBody />` に置換 |
| `src/app/admin/AdminClient.tsx` | 本文欄に「編集 / プレビュー」タブを追加 |

**共通コンポーネント化がこの実装の要点。** プレビューと本番で Markdown を別々に描画すると、プラグイン構成や `prose` クラスが必ずずれていく。同じコンポーネントを通すこと自体が「プレビュー＝本番の見た目」の保証になる。既存の記述は書き直さず、そのまま移設した。

**`ArticleBody` に `"use client"` は付けていない。** 記事詳細ページ（Server Component）ではサーバー描画のまま、`AdminClient` から import したときだけクライアントバンドルに入る。**公開記事ページのバンドルサイズは増えない。**

shadcn の Tabs は未導入のため、新規依存を足さず `TabButton` を自前で用意した。

### 規約チェックの表示

プレビュー時に **文字数 / h2の本数 / h3の本数** を表示し、`blog.md` で禁止されている **h4以下が使われていたら赤字で警告**する。数値で規定されている項目は、書いている最中でないと直しにくいため。

## 検証

### 1. 記事ページが無傷であること（最重要）

`ArticleBody` の切り出しは表示を変えない前提なので、ここが崩れたら失敗。**変更前（main）と変更後で同じ記事を描画し、本文HTMLをバイト単位で比較した。**

```
before.html  9,535 bytes  (main, :3200)
after.html   9,535 bytes  (本ブランチ, :3100)
diff → 差分なし（1文字も違わない）
```

見出し6個(h2) + 9個(h3) に対し目次アンカー15個が一致、`rehypeSlug` の id 付与・コードハイライトも従来どおり。

### 2. /admin のプレビュー

既存 draft の編集画面で、見出し・太字・インラインコード・リンク・リスト・テーブル・コードブロック・引用を含む本文を入力して確認：

- すべて記事ページと同じ見た目で描画される
- 統計に `272字 / h2: 1 / h3: 1 / h4以下あり（規約違反）`（赤字）が表示される
- 編集タブに戻ると入力内容が保持されている
- 本文が空のときはプレースホルダが出る

`biome check` / `tsc --noEmit` ともにクリーン。

## スコープ外

- 左右分割表示（タブ切替のみ）
- CTA・著者カード等の記事ページ周辺要素の再現 → #141 のプレビューURLで確認できる

## 備考

検証は既存 draft のフォーム上で行い、**保存はしていない**（DBは変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)