### PR TITLE
fix: BLOG_API_KEY の改行混入対策と定数時間比較を追加

### DIFF
--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
@@ -37,9 +38,20 @@ const REQUIRED_ON_CREATE: RequiredField[] = [
 
 function authenticate(request: Request): boolean {
   const auth = request.headers.get("Authorization");
-  const key = process.env.BLOG_API_KEY;
+  // Vercel の環境変数は貼り付け時に末尾へ改行が混入することがある。
+  // 見た目が同じでも "abc" と "abc\n" は厳密比較で一致しないため、
+  // 両辺を trim してから比較する（NEXT_PUBLIC_GA_ID と同種の対処）。
+  const key = process.env.BLOG_API_KEY?.trim();
   if (!key || !auth?.startsWith("Bearer ")) return false;
-  return auth.slice(7) === key;
+
+  const received = Buffer.from(auth.slice(7).trim());
+  const expected = Buffer.from(key);
+
+  // timingSafeEqual は長さが違うと例外を投げるので先に弾く。
+  // 長さの差は秘匿できないが、内容の総当たりは時間差から守る（preview.ts と同方針）。
+  if (received.length !== expected.length) return false;
+
+  return timingSafeEqual(received, expected);
 }
 
 function unauthorized() {


### PR DESCRIPTION
## 背景

本番 `https://www.ysdevelopment.jp/api/articles` への `GET` が、正しい `BLOG_API_KEY` を付けても記事0件（＝401 相当）を返す事象を確認した。ローカル dev サーバー経由では同じキーで正常に一覧が取得できるため、**環境変数の値そのものに差異がある**と考えられる。

このリポジトリは同種の事故を既に経験している（`3120741` fix: NEXT_PUBLIC_GA_ID に .trim() を追加して改行混入を防ぐ）。Vercel の環境変数入力欄に値を貼り付けると末尾に改行が入ることがあり、`"abc"` と `"abc\n"` は厳密比較で一致しない。

## 変更内容

`src/app/api/articles/route.ts` の `authenticate()` を2点修正。

1. **両辺を `.trim()`** — 環境変数側だけでなく受信トークン側も正規化する。送信側（curl の `-d @file` やシェル変数経由）で改行が付く経路もあるため
2. **`===` → `timingSafeEqual`** — 文字列比較は最初の不一致で打ち切るため、応答時間から先頭何文字が正しいか推定できる。全バイトを走査する比較に置き換えた。長さ不一致は例外を避けるため先に弾く（`src/lib/knowledge/preview.ts` と同方針）

fail-closed は維持している。`if (!key)` が trim 後の空文字も落とすため、`BLOG_API_KEY` が未設定・空文字の環境で認証が素通りすることはない。

## 確認したこと

- `npm run lint` → `Checked 50 files. No fixes applied.`
- `npx tsc --noEmit` → エラーなし
- ローカル dev 経由の `GET /api/articles` が 200 で記事一覧を返すこと（修正前から成立）

## 確認できていないこと

- **改行混入が本番 401 の原因である、という仮説は未実証。** HTTP ステータスコードを直接確認しておらず、「記事が存在するのにレスポンスが空」という間接証拠から推定している
- **本番での解消はデプロイ後でないと検証できない。** マージ後に本番 `GET` を叩き直す必要がある。仮説が外れていた場合は 401 が残るため、別途切り分けが要る
- 環境変数の実値は未確認（`.claude/hooks/block-env-read.py` によりアクセスがブロックされているため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)