### PR TITLE
feat: /admin の記事一覧にステータス絞り込みを追加

### DIFF
--- a/src/app/admin/_components/ArticleFilters.tsx
+++ b/src/app/admin/_components/ArticleFilters.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { ArticleFilters as Filters } from "../actions";
+import { type AdminSearchParams, buildAdminHref } from "./filters";
+
+// 選択肢が有限なのでリンクで組む。クライアントコンポーネントにしない。
+// 将来キーワード検索を足すときは、その入力欄だけを "use client" にすればよい。
+const STATUS_OPTIONS: { label: string; value: Filters["status"] }[] = [
+  { label: "すべて", value: undefined },
+  { label: "公開", value: "published" },
+  { label: "下書き", value: "draft" },
+];
+
+export function ArticleFilters({
+  searchParams,
+  filters,
+}: {
+  searchParams: AdminSearchParams;
+  filters: Filters;
+}) {
+  return (
+    <div className="flex items-center gap-1 rounded-lg bg-gray-100 p-1">
+      {STATUS_OPTIONS.map((option) => {
+        const active = filters.status === option.value;
+        return (
+          <Link
+            key={option.label}
+            href={buildAdminHref(searchParams, { status: option.value })}
+            aria-current={active ? "true" : undefined}
+            className={`rounded-md px-3 py-1 text-xs transition-colors ${
+              active
+                ? "bg-white font-bold text-gray-900 shadow-sm"
+                : "text-gray-500 hover:text-gray-900"
+            }`}
+          >
+            {option.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/admin/_components/ArticleList.tsx
+++ b/src/app/admin/_components/ArticleList.tsx
@@ -17,7 +17,13 @@ export type AdminArticle = {
   updated_at: string;
 };
 
-export function ArticleList({ articles }: { articles: AdminArticle[] }) {
+export function ArticleList({
+  articles,
+  isFiltered = false,
+}: {
+  articles: AdminArticle[];
+  isFiltered?: boolean;
+}) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -36,9 +42,10 @@ export function ArticleList({ articles }: { articles: AdminArticle[] }) {
   }
 
   if (articles.length === 0) {
+    // 絞り込みの結果 0 件なのか、そもそも記事が無いのかで意味が違う
     return (
       <p className="text-sm text-gray-400 text-center py-20">
-        記事がありません
+        {isFiltered ? "条件に一致する記事がありません" : "記事がありません"}
       </p>
     );
   }

--- a/src/app/admin/_components/filters.ts
+++ b/src/app/admin/_components/filters.ts
@@ -1,0 +1,58 @@
+import type { ArticleFilters } from "../actions";
+
+// URL のクエリパラメータが絞り込み条件の置き場。
+// パラメータの解釈とリンク先の組み立てをここ 1 箇所に集約する。
+// 条件を増やすときに触るのはこのファイルと ArticleFilters 型だけで済む。
+
+export type AdminSearchParams = Record<string, string | string[] | undefined>;
+
+const STATUSES = ["draft", "published"] as const;
+
+function single(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+// 不正な値は「指定なし」に倒す。
+// 任意の文字列をそのまま DB クエリに渡さないため、既知の値のみ通す。
+export function parseFilters(searchParams: AdminSearchParams): ArticleFilters {
+  const status = single(searchParams.status);
+
+  return {
+    status: STATUSES.includes(status as (typeof STATUSES)[number])
+      ? (status as ArticleFilters["status"])
+      : undefined,
+  };
+}
+
+// 既存のパラメータを保ったまま、指定したキーだけ差し替える。
+// undefined を渡すとそのキーを削除する（＝絞り込み解除）。
+//
+// 条件が増えても「他を保ったまま1つだけ変える」が自然に書けるようにするため、
+// 個別のリンクで URL を組み立てず必ずこれを通す。
+export function buildAdminHref(
+  searchParams: AdminSearchParams,
+  patch: Record<string, string | undefined>,
+): string {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    const v = single(value);
+    if (v) params.set(key, v);
+  }
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  return query ? `/admin?${query}` : "/admin";
+}
+
+// 絞り込みが 1 つでも掛かっているか（空状態の文言の出し分けに使う）
+export function hasActiveFilters(filters: ArticleFilters): boolean {
+  return Object.values(filters).some((v) => v !== undefined);
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -87,13 +87,28 @@ export async function deleteArticle(id: string) {
   revalidatePath("/knowledge");
 }
 
-export async function getAdminArticles() {
+// 一覧の絞り込み条件。増えた分はここに足し、getAdminArticles で条件を積む。
+export type ArticleFilters = {
+  status?: "draft" | "published";
+};
+
+export async function getAdminArticles(filters: ArticleFilters = {}) {
   assertAdminEnabled();
   const supabase = createServiceClient();
-  const { data, error } = await supabase
+
+  // 取得後に JS で絞ると記事が増えたときに全件取得が無駄になるため、
+  // 条件はクエリ側に積む。
+  let query = supabase
     .from("articles")
-    .select("id, title, slug, category, status, published_at, updated_at")
-    .order("updated_at", { ascending: false });
+    .select("id, title, slug, category, status, published_at, updated_at");
+
+  if (filters.status) {
+    query = query.eq("status", filters.status);
+  }
+
+  const { data, error } = await query.order("updated_at", {
+    ascending: false,
+  });
   if (error) throw new Error(error.message);
   return data ?? [];
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,26 +1,43 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { ArticleFilters } from "./_components/ArticleFilters";
 import { ArticleList } from "./_components/ArticleList";
+import {
+  type AdminSearchParams,
+  hasActiveFilters,
+  parseFilters,
+} from "./_components/filters";
 import { getAdminArticles } from "./actions";
 import { assertAdminPage } from "./guard";
 
-export default async function AdminPage() {
+export default async function AdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<AdminSearchParams>;
+}) {
   assertAdminPage();
-  const articles = await getAdminArticles();
+
+  const params = await searchParams;
+  const filters = parseFilters(params);
+  const articles = await getAdminArticles(filters);
 
   return (
     <>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
         <h2 className="text-lg font-bold text-gray-900">記事一覧</h2>
-        <Button
-          asChild
-          className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-4 py-2 h-auto text-sm"
-        >
-          <Link href="/admin/new">+ 新規作成</Link>
-        </Button>
+
+        <div className="flex items-center gap-3">
+          <ArticleFilters searchParams={params} filters={filters} />
+          <Button
+            asChild
+            className="bg-gray-900 hover:bg-gray-700 text-white rounded-lg px-4 py-2 h-auto text-sm"
+          >
+            <Link href="/admin/new">+ 新規作成</Link>
+          </Button>
+        </div>
       </div>
 
-      <ArticleList articles={articles} />
+      <ArticleList articles={articles} isFiltered={hasActiveFilters(filters)} />
     </>
   );
 }


### PR DESCRIPTION
## やること

記事一覧に「すべて / 公開 / 下書き」の絞り込みを追加する。配置は指定どおり「+ 新規作成」の左隣。

```
記事一覧          [すべて|公開|下書き]  [+ 新規作成]
```

## 設計：条件は URL のクエリパラメータに置く

```
/admin                      すべて
/admin?status=published     公開のみ
/admin?status=draft         下書きのみ
```

**「今後パラメータが増える」という要件がこの設計の理由です。** クライアントの `useState` で持つと、条件が増えるたびに状態・受け渡し・リセット処理の変更が波及します。URL に置けば `?status=draft&category=AI活用&q=議事録` と足していくだけで済みます。

副次的に、共有・ブックマーク・リロード・ブラウザの戻るにも耐えるようになります（#147 で新規・編集ページを URL 化したのと同じ考え方を一覧にも適用）。`/admin` は #147 で Server Component になっているため、URL パラメータならクライアント状態を持たずに絞り込みが完結します。

### 拡張点を 1 箇所に集約した

`src/app/admin/_components/filters.ts` に、パラメータの解釈と URL 組み立てをまとめました。**条件を増やすときに触るのはこのファイルと `ArticleFilters` 型だけです。**

- `parseFilters()` — 不正な値は「指定なし」に倒す。**`status` は既知の値のみ通す**（任意の文字列をそのまま DB クエリに渡さないため）
- `buildAdminHref()` — **既存のパラメータを保ったまま指定キーだけ差し替える**。`undefined` で削除

条件が増えたときに壊れるのはこの手の URL 組み立てなので、先に共通化しています。

### 絞り込みは DB クエリで行う

`getAdminArticles(filters)` に任意引数を足し、Supabase のクエリに条件を積みます。取得後に JS で絞る案もありますが、記事が増えたときに全件取得が無駄になるためクエリ側に寄せました。引数は省略可能なので**既存の呼び出しはそのまま動きます**。

### UI はリンク（クライアントコンポーネントにしない）

ステータスは選択肢が有限なので `<Link>` で足ります。`useRouter` も `"use client"` も不要です。将来キーワード検索を足すときは、その入力欄だけをクライアントコンポーネントにすれば済みます。

## 検証

`biome check` / `tsc --noEmit` 通過。ローカルの dev サーバーで確認：

| 項目 | 結果 |
|---|---|
| `/admin` 全6件表示、「すべて」が選択状態 | ✅ |
| 「公開」→ `?status=published`、公開2件のみ | ✅ |
| 「下書き」→ `?status=draft`、下書き4件のみ | ✅ |
| `?status=invalid` で落ちず全件表示 | ✅ |
| 直接リロードで絞り込みが保たれる | ✅ |
| ブラウザの戻るで前の状態に戻る | ✅ |

**拡張性の確認（今回の要件の核心）** — `?status=draft&category=test&page=2` の状態で各リンクの `href` を検証：

```
すべて → /admin?category=test&page=2            （status のみ削除）
公開   → /admin?status=published&category=test&page=2
下書き → /admin?status=draft&category=test&page=2
```

**未知のパラメータ（`category` / `page`）がそのまま維持され、`status` だけが差し替わる**ことを確認しました。

## 対象ファイル

- `src/app/admin/_components/filters.ts`（新規・拡張点）
- `src/app/admin/_components/ArticleFilters.tsx`（新規・UI）
- `src/app/admin/actions.ts`（`ArticleFilters` 型と `filters` 引数）
- `src/app/admin/page.tsx`（`searchParams` を受け取る）
- `src/app/admin/_components/ArticleList.tsx`（0件時の文言を出し分け）

## スコープ外

カテゴリ・タグ・キーワードでの絞り込みは**構造だけ用意し、実装はしていません**。並び替え・ページネーション・件数バッジも今回は対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)