### PR TITLE
style: 記事本文の画像を実寸比率で表示しキャプションを追加

### DIFF
--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -1,3 +1,4 @@
+import type { Element } from "hast";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
@@ -12,6 +13,19 @@ import remarkGfm from "remark-gfm";
 // "use client" は付けない：記事詳細ページ（Server Component）では
 // サーバー描画のまま、AdminClient から import したときだけ
 // クライアントバンドルに含まれる。
+// 中身が画像1枚だけの段落か（前後の空白テキストは無視する）
+function isImageOnlyParagraph(node: Element | undefined) {
+  if (!node) return false;
+  const meaningful = node.children.filter(
+    (child) => !(child.type === "text" && child.value.trim() === ""),
+  );
+  return (
+    meaningful.length === 1 &&
+    meaningful[0].type === "element" &&
+    meaningful[0].tagName === "img"
+  );
+}
+
 export function ArticleBody({ content }: { content: string }) {
   return (
     <div className="prose prose-neutral prose-headings:font-bold prose-headings:text-gray-900 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded max-w-none">
@@ -19,21 +33,34 @@ export function ArticleBody({ content }: { content: string }) {
         remarkPlugins={[remarkGfm, remarkFootnotes as never]}
         rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}
         components={{
+          // 画像だけの段落は p を外す。
+          // markdown の `![](...)` は <p> に包まれるが、img を figure に
+          // 置き換えると <p> 内に <figure> が入り HTML として不正になるため。
+          p({ node, children }) {
+            return isImageOnlyParagraph(node) ? children : <p>{children}</p>;
+          },
           img({ src, alt }) {
             if (!src || typeof src !== "string") return null;
             return (
-              <span
-                className="block relative w-full"
-                style={{ aspectRatio: "16/9" }}
-              >
+              <figure className="my-6">
+                {/* 縦横比は画像の実寸に従わせる。16:9 固定だと縦長の
+                    スクリーンショットが左右の余白に潰されるため。
+                    width/height は読み込み前の場所取り用の目安値。 */}
                 <Image
                   src={src}
                   alt={alt ?? ""}
-                  fill
-                  className="object-contain rounded-lg"
+                  width={1600}
+                  height={900}
+                  sizes="(max-width: 768px) 100vw, 768px"
+                  className="mx-auto h-auto max-h-[70vh] w-auto max-w-full rounded-lg border border-gray-200"
                   loading="lazy"
                 />
-              </span>
+                {alt && (
+                  <figcaption className="mt-2 text-center text-xs text-gray-500">
+                    {alt}
+                  </figcaption>
+                )}
+              </figure>
             );
           },
         }}


### PR DESCRIPTION
## 概要

画像を入れやすくする段階2。本文画像の表示品質を直します。#151（挿入導線）と対になる変更で、依存はないので順不同でマージできます。

## 変更前の問題

`aspectRatio: "16/9"` 固定 + `object-contain` だったため、**縦長のスクリーンショットが左右の余白に潰されて極端に小さく表示される**状態でした。ブログの第一読者はスマホ閲覧が主で、記事に載せる画像もスマホのスクショが多くなるため実用上効いてきます。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 縦横比 | 16:9 固定 | 画像の実寸比率 |
| 高さの上限 | なし（枠が常に16:9） | `max-h-[70vh]` |
| キャプション | なし | `alt` を `figcaption` で表示 |
| マークアップ | `<span>` | `<figure>` / `<figcaption>` |

## なぜ

- **なぜ `fill` をやめたか** — `fill` は親要素のサイズに従うため、比率を固定せざるを得ない。実寸比率にするには通常の `width`/`height` + `h-auto` にする必要がある
- **なぜ `width={1600} height={900}` を残すか** — next/image は非 `fill` では必須。CSS 側で `h-auto w-auto` にしているので表示比率には影響せず、読み込み前の場所取りの目安としてのみ働く
- **なぜ `max-h-[70vh]` を入れたか** — 実寸比率にすると縦長画像が画面を丸ごと占有し、読み進めが途切れる
- **なぜ画像だけの段落から `p` を外すか** — markdown の `![](...)` は `<p>` に包まれる。`img` を `<figure>` に置き換えると `<p>` 内に `<figure>` が入り、HTML として不正になってブラウザが `p` を強制的に閉じる。従来 `<span className="block">` だったのはこれを避けるためだが、`span` ではキャプションを意味的に表現できない

## デザイン上の判断

画像に `border border-gray-200` を追加しています。白背景のスクリーンショットが記事の地色と溶けて境界が分からなくなるためです。不要であれば外します。

## ⚠️ 未検証

**ローカル起動での見た目確認ができていません。**`.env` へのアクセスが hook でブロックされているためです。lint と型チェックは通っています。

レビュー時に以下をご確認ください：
- 横長・縦長それぞれの画像が意図通りに表示されるか
- alt がキャプションとして出るか（装飾画像で邪魔にならないか）
- `/admin` のプレビューと記事詳細で同じ見た目になるか

## 確認

- [x] `npm run lint` — 58 files クリーン
- [x] `npx tsc --noEmit` — エラーなし
- [ ] ローカルでの表示確認（未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)