### PR TITLE
feat: 記事一覧からプレビューを開けるようにする

### DIFF
--- a/src/app/admin/[id]/preview/page.tsx
+++ b/src/app/admin/[id]/preview/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArticleView } from "@/components/ArticleView";
+import { getAdminArticleById } from "../../actions";
+import { assertAdminPage } from "../../guard";
+
+// 保存済み記事を公開ページと同じ見た目で確認するページ。
+//
+// PREVIEW_TOKEN を使う /knowledge/[slug]?preview= とは経路を分けている。
+// 一覧からリンクする以上トークンをクライアントに渡すことになり、
+// 認証情報をクライアントコードに埋め込まない方針に反するため。
+// admin は ADMIN_ENABLED でローカル限定なので、ここでは認証が要らない。
+export default async function PreviewArticlePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  assertAdminPage();
+  const { id } = await params;
+  const article = await getAdminArticleById(id);
+
+  if (!article) {
+    notFound();
+  }
+
+  const tagNames: string[] = article.tagNames ?? [];
+
+  return (
+    // admin layout の max-w-4xl / px-6 / py-10 を打ち消して全幅で描く。
+    // 公開ページと同じ幅で見せることがこのページの目的なので、
+    // 管理画面のコンテナ幅に収めると意味がなくなる。
+    <div className="relative left-1/2 -my-10 w-screen -translate-x-1/2 bg-white">
+      {/* sticky にはしない。サイト共通ヘッダーも sticky で、その背面に隠れる。
+          ヘッダー高さ分の top オフセットを数値で決め打ちすると、
+          ヘッダーを変えたときに静かに壊れるため。 */}
+      <div className="flex items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2">
+        <span className="text-xs font-bold text-amber-800">
+          プレビュー（
+          {article.status === "published" ? "公開済み" : "下書き"}）
+        </span>
+        <Link
+          href={`/admin/${id}/edit`}
+          className="ml-auto rounded-md border border-amber-300 bg-white px-3 py-1 text-xs text-amber-900 transition-colors hover:bg-amber-100"
+        >
+          編集する
+        </Link>
+        <Link
+          href="/admin"
+          className="rounded-md border border-amber-300 bg-white px-3 py-1 text-xs text-amber-900 transition-colors hover:bg-amber-100"
+        >
+          一覧へ戻る
+        </Link>
+      </div>
+
+      <ArticleView
+        title={article.title}
+        category={article.category ?? ""}
+        tags={tagNames}
+        content={article.content ?? ""}
+        thumbnailUrl={article.thumbnail_url ?? null}
+        publishedAt={article.published_at ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/_components/ArticleList.tsx
+++ b/src/app/admin/_components/ArticleList.tsx
@@ -87,6 +87,13 @@ export function ArticleList({
               variant="outline"
               className="h-auto py-1.5 px-3 text-xs rounded-lg"
             >
+              <Link href={`/admin/${a.id}/preview`}>プレビュー</Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="h-auto py-1.5 px-3 text-xs rounded-lg"
+            >
               <Link href={`/admin/${a.id}/edit`}>編集</Link>
             </Button>
             <Button


### PR DESCRIPTION
## 背景

PR #154 で編集画面から記事全体をプレビューできるようになったが、一覧からは記事を開かないと見た目を確認できなかった。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/admin/[id]/preview/page.tsx` | 新規。`getAdminArticleById` で取得し `ArticleView` で描画 |
| `src/app/admin/_components/ArticleList.tsx` | 「編集」の左に「プレビュー」を追加（`プレビュー / 編集 / 削除`） |

## 設計判断

- **`?preview=<TOKEN>` を使わなかった理由**: 一覧からリンクするには `PREVIEW_TOKEN` をクライアント側に渡す必要があり、`blog.md` のガードレール（認証情報のクライアントコードへの埋め込み禁止）に反する。admin は `ADMIN_ENABLED` でローカル限定なので、専用ページなら認証自体が不要
- **`w-screen` + `-translate-x-1/2` で全幅化**: admin layout の `max-w-4xl px-6` に収めると本文が公開ページより 48px 狭くなり、「公開後と同じ見た目」という目的を果たさないため
- **バナーを `sticky` にしなかった理由**: 実機で確認したところ、サイト共通ヘッダー（同じく sticky）の背面に隠れて消えた。ヘッダー高さ分の top オフセットを決め打ちすると、ヘッダー変更時に静かに壊れるため通常配置にした

## 確認

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] ブラウザ目視（公開済み記事・下書き記事の両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)