### PR TITLE
docs: 検証スクリーンショットの置き場とマージ後の削除ルールを追加

### DIFF
--- a/.claude/rules/github.md
+++ b/.claude/rules/github.md
@@ -96,3 +96,27 @@ gh issue comment <Issue番号> --body "..." # Issue に記録
 - 結果: ✅ 問題なし / ⚠️ 軽微な指摘あり / ❌ 要修正
 - 備考: （任意）
 ```
+
+## 検証スクリーンショットの置き場
+
+UI の変更をブラウザで目視確認した場合、スクリーンショットを `tmp/PR/` に保存する。
+
+```
+tmp/PR/pr<PR番号>-<内容>.jpg    # 例: tmp/PR/pr155-admin-list.jpg
+```
+
+- `tmp/` は `.gitignore` 済みなので、リポジトリには載らない
+- **Claude は PR コメントに画像を貼れない。** `gh` CLI に画像アップロード機能が無く、GitHub 側にも公開 API が無いため。Claude はファイルを置いてパスを伝えるところまでを行い、**PR への添付は人間が Web UI でドラッグ&ドロップする**
+- PR 本文の確認欄に「ブラウザ目視」と書く場合、スクショの添付は人間の作業として残っていることを明示する
+
+### PR マージ後の削除（必須）
+
+worktree の削除と同じタイミングで、その PR のスクショも削除する。
+
+```bash
+git worktree remove ../portfolio-<branch-name>
+git branch -d <branch-name>
+rm -f tmp/PR/pr<PR番号>-*        # 対象 PR のスクショのみ削除
+```
+
+`tmp/PR/` ごと消さないこと。他の未マージ PR のスクショが残っている場合があるため。


### PR DESCRIPTION
## 背景

UI 変更の目視確認をした際、スクリーンショットの置き場が決まっておらず、また Claude が PR に画像を貼れないことがルール上どこにも書かれていなかった。PR #155 で「ブラウザ目視 ✅」とだけ書き、スクショが添付されないまま報告してしまった。

## 変更内容

`.claude/rules/github.md` に「検証スクリーンショットの置き場」節を追加。

- 保存先を `tmp/PR/pr<PR番号>-<内容>.jpg` に固定（`tmp/` は `.gitignore` 済み）
- Claude は画像を PR に貼れないことを明記し、添付は人間の作業だと役割を分ける
- **PR マージ後、worktree 削除と同じタイミングでスクショも削除**する手順を追加

## 補足

`rm -rf tmp/PR` ではなく `rm -f tmp/PR/pr<PR番号>-*` と限定しています。他の未マージ PR のスクショを巻き込まないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)