### PR TITLE
feat: 本番の公開記事キャッシュを外部から再検証できるようにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,14 @@ BLOG_API_BASE_URL=http://localhost:3000
 # 未設定・空の環境ではプレビュー機能は無効（draft は 404）
 PREVIEW_TOKEN=your_preview_token_here
 
+# 公開記事キャッシュの再検証
+# POST /api/revalidate に Bearer で渡す。本番の一覧・サイトマップを更新する唯一の外部経路
+# 未設定・空の環境では 401（fail closed）
+REVALIDATE_TOKEN=your_revalidate_token_here
+# ローカル管理画面での保存時に、この URL の /api/revalidate も叩く
+# 未設定なら本番は触らない（例: https://www.ysdevelopment.jp）
+REVALIDATE_TARGET_URL=
+
 # Google Analytics 4
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -16,6 +16,37 @@ function assertAdminEnabled() {
   }
 }
 
+// 本番のキャッシュ再検証を呼ぶ。
+//
+// revalidateTag() はそのプロセスのキャッシュにしか効かない。admin は
+// ADMIN_ENABLED でローカル限定のため、ローカルで公開しても本番の一覧・
+// サイトマップは古いまま残る（getPublishedArticles は revalidate: 86400）。
+// 本番へ届かせるには HTTP で叩くしかない。
+//
+// 失敗しても保存は成功扱いにする。記事は Supabase に保存済みであり、
+// ここで throw すると「保存できなかった」と誤解させるため。
+// 反映されなくても revalidate: 86400 で最終的には追いつく。
+//
+// 未設定の環境では何もしない。ローカル検証だけしたい場合に
+// 本番を触らずに済ませるため（設定して初めて本番へ届く）。
+async function revalidateProduction() {
+  const url = process.env.REVALIDATE_TARGET_URL?.trim();
+  const token = process.env.REVALIDATE_TOKEN?.trim();
+  if (!url || !token) return;
+
+  try {
+    const res = await fetch(`${url}/api/revalidate`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      console.error(`本番キャッシュの再検証に失敗しました: HTTP ${res.status}`);
+    }
+  } catch (e) {
+    console.error("本番キャッシュの再検証に失敗しました", e);
+  }
+}
+
 export type ArticleInput = {
   title: string;
   slug: string;
@@ -49,6 +80,7 @@ export async function createArticle(input: ArticleInput) {
   await syncArticleTags(supabase, data.id, tagIds);
 
   revalidateTag("published-articles");
+  await revalidateProduction();
   revalidatePath("/admin");
   revalidatePath("/knowledge");
 }
@@ -73,6 +105,7 @@ export async function updateArticle(id: string, input: ArticleInput) {
   await syncArticleTags(supabase, id, tagIds);
 
   revalidateTag("published-articles");
+  await revalidateProduction();
   revalidatePath("/admin");
   revalidatePath("/knowledge");
 }
@@ -83,6 +116,7 @@ export async function deleteArticle(id: string) {
   const { error } = await supabase.from("articles").delete().eq("id", id);
   if (error) throw new Error(error.message);
   revalidateTag("published-articles");
+  await revalidateProduction();
   revalidatePath("/admin");
   revalidatePath("/knowledge");
 }

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,6 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
+import { verifyBearerToken } from "@/lib/api-auth";
 import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
 import { createServiceClient } from "@/lib/supabase/service";
 
@@ -37,21 +37,10 @@ const REQUIRED_ON_CREATE: RequiredField[] = [
 ];
 
 function authenticate(request: Request): boolean {
-  const auth = request.headers.get("Authorization");
-  // Vercel の環境変数は貼り付け時に末尾へ改行が混入することがある。
-  // 見た目が同じでも "abc" と "abc\n" は厳密比較で一致しないため、
-  // 両辺を trim してから比較する（NEXT_PUBLIC_GA_ID と同種の対処）。
-  const key = process.env.BLOG_API_KEY?.trim();
-  if (!key || !auth?.startsWith("Bearer ")) return false;
-
-  const received = Buffer.from(auth.slice(7).trim());
-  const expected = Buffer.from(key);
-
-  // timingSafeEqual は長さが違うと例外を投げるので先に弾く。
-  // 長さの差は秘匿できないが、内容の総当たりは時間差から守る（preview.ts と同方針）。
-  if (received.length !== expected.length) return false;
-
-  return timingSafeEqual(received, expected);
+  return verifyBearerToken(
+    request.headers.get("Authorization"),
+    process.env.BLOG_API_KEY,
+  );
 }
 
 function unauthorized() {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,33 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+import { verifyBearerToken } from "@/lib/api-auth";
+
+// 公開記事キャッシュの再検証エンドポイント。
+//
+// 記事の追加・公開は Supabase 上で起きるが、revalidateTag を呼ぶ
+// admin は ADMIN_ENABLED でローカル限定のため、本番のキャッシュには届かない。
+// 結果として「公開したのに本番の一覧・サイトマップに出ない」が起きる
+// （getPublishedArticles は revalidate: 86400 でキャッシュされる）。
+// 本番の外から再検証を起こせる唯一の経路がこのルート。
+//
+// BLOG_API_KEY とは別トークンにしている。記事の読み書き権限と
+// キャッシュ破棄の権限は影響範囲が違うため、片方が漏れても
+// もう片方が巻き込まれないようにする。
+export async function POST(request: Request) {
+  const authorized = verifyBearerToken(
+    request.headers.get("Authorization"),
+    process.env.REVALIDATE_TOKEN,
+  );
+
+  if (!authorized) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag("published-articles");
+
+  return NextResponse.json({
+    revalidated: true,
+    tag: "published-articles",
+    now: new Date().toISOString(),
+  });
+}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,26 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Bearer トークンの照合。
+//
+// fail closed：期待値が未設定・空文字の環境では常に false を返す。
+// 設定漏れの環境でエンドポイントが誰でも叩ける事故を防ぐため
+// （preview.ts の isValidPreviewToken と同方針）。
+export function verifyBearerToken(
+  authorizationHeader: string | null,
+  expectedToken: string | undefined,
+): boolean {
+  // Vercel の環境変数は貼り付け時に末尾へ改行が混入することがある。
+  // 見た目が同じでも "abc" と "abc\n" は厳密比較で一致しないため、
+  // 両辺を trim してから比較する（NEXT_PUBLIC_GA_ID と同種の対処）。
+  const key = expectedToken?.trim();
+  if (!key || !authorizationHeader?.startsWith("Bearer ")) return false;
+
+  const received = Buffer.from(authorizationHeader.slice(7).trim());
+  const expected = Buffer.from(key);
+
+  // timingSafeEqual は長さが違うと例外を投げるので先に弾く。
+  // 長さの差は秘匿できないが、内容の総当たりは時間差から守る。
+  if (received.length !== expected.length) return false;
+
+  return timingSafeEqual(received, expected);
+}


### PR DESCRIPTION
## 背景

本番の `/knowledge` とサイトマップに、公開済みの記事2件が出ていなかった。

原因はバグではなくキャッシュの経路の断絶。`getPublishedArticles` は `unstable_cache`（`revalidate: 86400` / タグ `published-articles`）で包まれているが、`revalidateTag()` を呼ぶ `admin` は `ADMIN_ENABLED` でローカル限定のため、ローカルで公開しても本番のキャッシュには届かない。**記事を公開するたびに最大24時間ズレる**状態だった。

サイトマップも同じ `getPublishedArticles` を使っているため、同様に古い内容を配信していた。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/api/revalidate/route.ts` | 新規。`POST` + Bearer 認証で `revalidateTag("published-articles")` |
| `src/lib/api-auth.ts` | 新規。Bearer 照合を共通化（`timingSafeEqual` / `.trim()` / fail closed） |
| `src/app/admin/actions.ts` | 保存時に `REVALIDATE_TARGET_URL` の `/api/revalidate` を呼ぶ |
| `src/app/api/articles/route.ts` | 自前の `authenticate` を共通関数へ差し替え（挙動は同一） |
| `.env.example` | `REVALIDATE_TOKEN` / `REVALIDATE_TARGET_URL` を追記 |

## 設計判断

- **`BLOG_API_KEY` を使い回さない**: 記事の読み書き権限とキャッシュ破棄の権限は影響範囲が違う。片方が漏れてももう片方を巻き込まないため
- **再検証の失敗で保存を失敗させない**: 記事は Supabase に保存済み。ここで throw すると「保存できなかった」と誤解させ再保存による重複を招く。反映されなくても `revalidate: 86400` で最終的には追いつく
- **未設定なら何もしない**: `REVALIDATE_TARGET_URL` が空なら本番を触らない。検証用の環境が誤って本番を叩く事故を防ぐ
- **`BLOG_API_BASE_URL` を再利用しない**: あちらはローカルを指す。同じ変数に本番 URL を入れると記事APIの接続先まで本番に向く
- **認証ロジックの共通化**: 同じ照合を3箇所目に書くことになるため。`.trim()` 忘れ（`vercel.md` に過去2件の事例）の対処が片方だけに入る事故を防ぐ

## 検証（ローカル 3113）

| 項目 | 結果 |
|---|---|
| 正しいトークン | ✅ 200 `{"revalidated":true,...}` |
| 誤ったトークン / ヘッダーなし | ✅ 401 |
| `GET` | ✅ 405 |
| 既存 `/api/articles` のデグレ | ✅ 無し（401 のまま） |
| 一覧・サイトマップが4件返る | ✅ |
| 再検証でキャッシュが失効する | ✅ 応答時間で確認（下記） |

一覧: キャッシュヒット 0.049s → 再検証直後 0.318s（再クエリ）
サイトマップ: ヒット 0.232s → 再検証直後 0.326s → 再びヒット 0.226s

※ 応答時間からの間接証拠。決定的な確認には記事データの書き換えが必要なため、本番データを避けて実施していない。

## マージ後に必要な設定（重要）

1. Vercel に `REVALIDATE_TOKEN` を設定（本番用に新規生成した値）
2. ローカル `.env.local` に同じ `REVALIDATE_TOKEN` と `REVALIDATE_TARGET_URL=https://www.ysdevelopment.jp` を設定
3. **Vercel を再デプロイ** — 環境変数は既存デプロイに遡って反映されない（`vercel.md`）。これを忘れると `/api/revalidate` は fail closed で 401 を返し続ける

## 別途検討したい点（本PRでは未対応）

`src/lib/knowledge/index.ts:52` の `if (error || !data) return []` により、**Supabase への接続が失敗しても空配列を返す**。検証中に実際に踏み、認証情報が無い状態で「記事0件」として正常描画された。本番で障害や設定ミスが起きると、サイトマップから全記事が消えた XML を 200 で配信することになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)