### PR TITLE
refactor: 再検証まわりの新規環境変数を廃止する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # Blog API
+# 記事APIの認証。POST /api/revalidate（公開記事キャッシュの再検証）にも使う
 BLOG_API_KEY=your_blog_api_key_here
 # 記事APIの接続先。プレビューURLの組み立てにも使う（例: http://localhost:3000）
 BLOG_API_BASE_URL=http://localhost:3000
@@ -22,14 +23,6 @@ BLOG_API_BASE_URL=http://localhost:3000
 # /knowledge/<slug>?preview=<PREVIEW_TOKEN> で未公開記事を閲覧できる
 # 未設定・空の環境ではプレビュー機能は無効（draft は 404）
 PREVIEW_TOKEN=your_preview_token_here
-
-# 公開記事キャッシュの再検証
-# POST /api/revalidate に Bearer で渡す。本番の一覧・サイトマップを更新する唯一の外部経路
-# 未設定・空の環境では 401（fail closed）
-REVALIDATE_TOKEN=your_revalidate_token_here
-# ローカル管理画面での保存時に、この URL の /api/revalidate も叩く
-# 未設定なら本番は触らない（例: https://www.ysdevelopment.jp）
-REVALIDATE_TARGET_URL=
 
 # Google Analytics 4
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath, revalidateTag } from "next/cache";
 import { syncArticleTags, upsertTags } from "@/lib/knowledge/write";
+import { SITE_URL } from "@/lib/site";
 import { createServiceClient } from "@/lib/supabase/service";
 
 // "use server" のファイルでは export した関数がすべて Server Action として
@@ -23,19 +24,19 @@ function assertAdminEnabled() {
 // サイトマップは古いまま残る（getPublishedArticles は revalidate: 86400）。
 // 本番へ届かせるには HTTP で叩くしかない。
 //
+// 時間ベースの短い revalidate ではなくこの方式にしている。記事が変わらない
+// 期間も定期的に問い合わせ続けるのは無駄で、変更した瞬間だけ1回無効化すれば
+// 足りるため。
+//
 // 失敗しても保存は成功扱いにする。記事は Supabase に保存済みであり、
 // ここで throw すると「保存できなかった」と誤解させるため。
 // 反映されなくても revalidate: 86400 で最終的には追いつく。
-//
-// 未設定の環境では何もしない。ローカル検証だけしたい場合に
-// 本番を触らずに済ませるため（設定して初めて本番へ届く）。
 async function revalidateProduction() {
-  const url = process.env.REVALIDATE_TARGET_URL?.trim();
-  const token = process.env.REVALIDATE_TOKEN?.trim();
-  if (!url || !token) return;
+  const token = process.env.BLOG_API_KEY?.trim();
+  if (!token) return;
 
   try {
-    const res = await fetch(`${url}/api/revalidate`, {
+    const res = await fetch(`${SITE_URL}/api/revalidate`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -10,13 +10,14 @@ import { verifyBearerToken } from "@/lib/api-auth";
 // （getPublishedArticles は revalidate: 86400 でキャッシュされる）。
 // 本番の外から再検証を起こせる唯一の経路がこのルート。
 //
-// BLOG_API_KEY とは別トークンにしている。記事の読み書き権限と
-// キャッシュ破棄の権限は影響範囲が違うため、片方が漏れても
-// もう片方が巻き込まれないようにする。
+// 認証は BLOG_API_KEY を流用する。専用トークンを分ける案もあったが、
+// 漏洩時の被害が非対称すぎて分離の価値が小さい：BLOG_API_KEY が漏れれば
+// 記事を書き換えられるのに対し、キャッシュ破棄でできるのは本番を一度
+// 再クエリさせることだけ。変数を増やす設定コストのほうが上回る。
 export async function POST(request: Request) {
   const authorized = verifyBearerToken(
     request.headers.get("Authorization"),
-    process.env.REVALIDATE_TOKEN,
+    process.env.BLOG_API_KEY,
   );
 
   if (!authorized) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
 import type { ReactNode } from "react";
+import { SITE_URL } from "@/lib/site";
 import { GoogleAnalytics } from "./_components/GoogleAnalytics";
 import { Header } from "./_components/Header";
 
@@ -26,7 +27,7 @@ export const metadata: Metadata = {
   },
   description:
     "福祉×IT・AIの視点で発信するフリーランスエンジニア。社会福祉士の資格と6年のエンジニア経験を活かし、福祉業界のDX・AI導入支援を行っています。",
-  metadataBase: new URL("https://www.ysdevelopment.jp"),
+  metadataBase: new URL(SITE_URL),
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -7,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/admin/", "/api/"],
     },
-    sitemap: "https://www.ysdevelopment.jp/sitemap.xml",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,14 @@
 import type { MetadataRoute } from "next";
 import { getPublishedArticles } from "@/lib/knowledge";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-dynamic";
-
-const BASE_URL = "https://www.ysdevelopment.jp";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const articles = await getPublishedArticles();
 
   const articleEntries: MetadataRoute.Sitemap = articles.map((article) => ({
-    url: `${BASE_URL}/knowledge/${article.slug}`,
+    url: `${SITE_URL}/knowledge/${article.slug}`,
     lastModified: new Date(article.updated_at),
     changeFrequency: "weekly",
     priority: 0.7,
@@ -17,19 +16,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     {
-      url: BASE_URL,
+      url: SITE_URL,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1.0,
     },
     {
-      url: `${BASE_URL}/knowledge`,
+      url: `${SITE_URL}/knowledge`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.8,
     },
     {
-      url: `${BASE_URL}/contact`,
+      url: `${SITE_URL}/contact`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.5,

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,9 @@
+// 本番サイトの URL。
+//
+// 環境変数にしていない。本番は1つしかなく、切り替える必要が無いため。
+// 環境変数にすると Vercel・ローカル双方への設定が必要になり、
+// 「環境変数は既存デプロイに遡らない」（vercel.md）を踏む機会も増える。
+//
+// layout.tsx（metadataBase）・sitemap.ts・robots.ts・admin/actions.ts が参照する。
+// 以前は3箇所に同じ文字列がハードコードされていた。
+export const SITE_URL = "https://www.ysdevelopment.jp";


### PR DESCRIPTION
## 背景

PR #159 は設計としては妥当だったが、新規環境変数を2つ増やしていた。どちらも不要だったため削除する。

「記事を変更したときだけ1回無効化する」というイベント駆動の方式自体は維持する。時間ベースの短い `revalidate` は、記事が変わらない期間も定期的に問い合わせ続けるため要件に合わない。

## 変更内容

| 削除した変数 | 置き換え | 理由 |
|---|---|---|
| `REVALIDATE_TOKEN` | `BLOG_API_KEY` | Vercel・ローカル双方に設定済み。新規発行が不要になる |
| `REVALIDATE_TARGET_URL` | `SITE_URL` 定数 | 本番は1つしかなく、切り替える必要が無い |

あわせて `src/lib/site.ts` を新設。本番 URL は `layout.tsx` / `sitemap.ts` / `robots.ts` の3箇所に同じ文字列がハードコードされていたので、ここに集約した。

| ファイル | 変更 |
|---|---|
| `src/lib/site.ts` | 新規。`SITE_URL` |
| `src/app/layout.tsx` | `metadataBase` を `SITE_URL` 参照に |
| `src/app/sitemap.ts` | ローカルの `BASE_URL` を廃止し `SITE_URL` に |
| `src/app/robots.ts` | ハードコードを `SITE_URL` に |
| `src/app/api/revalidate/route.ts` | 認証を `BLOG_API_KEY` に |
| `src/app/admin/actions.ts` | `SITE_URL` へ送信。URL の環境変数分岐を削除 |
| `.env.example` | 2行削除 |

## 設計判断

**トークンを分離しなかった理由**: 漏洩時の被害が非対称。`BLOG_API_KEY` が漏れれば記事を書き換えられるのに対し、キャッシュ破棄でできるのは本番を一度再クエリさせることだけ。分離の価値より、Vercel とローカル双方への設定・「環境変数は既存デプロイに遡らない」（`vercel.md`）を踏む機会が増えるコストのほうが上回る。

**URL を定数にした理由**: 本番は1つで切り替え要件が無い。副次的に、既存の3箇所のハードコード重複も解消される。

なお `REVALIDATE_TARGET_URL` の削除により、ローカルでの保存は常に本番へ再検証を送るようになる。これは「ローカルで公開したら本番に反映される」という要件そのもの。

## 検証（ローカル 3114）

| 項目 | 結果 |
|---|---|
| 認証なし / 誤トークン | ✅ 401 |
| `BLOG_API_KEY` で認証 | ✅ 200 `{"revalidated":true,...}` |
| 旧 `REVALIDATE_TOKEN` の値 | ✅ 401（無効化を確認） |
| `sitemap.xml`（定数化後） | ✅ 全 URL 正常・記事4件 |
| `robots.txt`（定数化後） | ✅ 正常 |
| `/knowledge` | ✅ 4件 |

## マージ後

**追加の設定作業は不要。** `BLOG_API_KEY` は Vercel に設定済みのため、マージしてデプロイされれば動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)