### PR TITLE
fix: Supabase 取得失敗時に空配列を返さないようにする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,18 @@ import HomeClient from "./HomeClient";
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const articles = await getPublishedArticles(3);
+  // ホームの記事セクションは補助的な要素なので、取得に失敗しても
+  // ページ全体を 500 にはしない。トップが落ちる損失のほうが大きい。
+  //
+  // 一覧（/knowledge）とサイトマップでは逆に握り潰さない。
+  // あちらは記事が本体で、空のまま 200 を返すと検索エンジンに
+  // 「記事が無いサイト」と伝えてしまうため。
+  let articles: Awaited<ReturnType<typeof getPublishedArticles>> = [];
+  try {
+    articles = await getPublishedArticles(3);
+  } catch (e) {
+    console.error("ホームの記事セクションの取得に失敗しました", e);
+  }
+
   return <HomeClient articles={articles} />;
 }

--- a/src/lib/knowledge/index.ts
+++ b/src/lib/knowledge/index.ts
@@ -21,6 +21,10 @@ type ArticleRow = Omit<Article, "tags"> & {
   article_tags: { tags: { id: string; name: string } | null }[];
 };
 
+// PostgREST が .single() で0件だったときに返すコード。
+// 「記事が無い」と「取得に失敗した」を区別するために使う。
+const NO_ROWS_RETURNED = "PGRST116";
+
 function toArticle(row: ArticleRow): Article {
   return {
     ...row,
@@ -49,9 +53,20 @@ export const getPublishedArticles = unstable_cache(
 
     const { data, error } = await query;
 
-    if (error || !data) return [];
+    // 取得に失敗したら握りつぶさず投げる。
+    //
+    // 以前は空配列を返していたが、これは事故になる：サイトマップが
+    // 「記事0件」の XML を 200 で配信し、Google にインデックス削除と
+    // 解釈されうる。さらに unstable_cache は返り値をキャッシュするため、
+    // 一時的な障害の結果が最大24時間居座る（例外はキャッシュされない）。
+    //
+    // 呼び出し側の判断で握り潰したい場合（ホームの記事セクション等）は、
+    // 各ページで catch する。ここでは事実を返すことに徹する。
+    if (error) {
+      throw new Error(`公開記事の取得に失敗しました: ${error.message}`);
+    }
 
-    return data.map(toArticle);
+    return (data ?? []).map(toArticle);
   },
   ["published-articles"],
   { revalidate: 86400, tags: ["published-articles"] },
@@ -68,9 +83,15 @@ export const getArticleBySlug = unstable_cache(
       .eq("status", "published")
       .single();
 
-    if (error || !data) return undefined;
+    // 0件（未公開・存在しない）は undefined を返し、呼び出し側で 404 にする。
+    // それ以外のエラーは投げる。区別しないと、一時的な障害で公開中の記事が
+    // 404 になり、検索エンジンに存在しないページと見なされる。
+    if (error) {
+      if (error.code === NO_ROWS_RETURNED) return undefined;
+      throw new Error(`記事の取得に失敗しました（${slug}）: ${error.message}`);
+    }
 
-    return toArticle(data);
+    return data ? toArticle(data) : undefined;
   },
   ["article-by-slug"],
   { revalidate: 86400, tags: ["published-articles"] },
@@ -93,7 +114,10 @@ export async function getArticleBySlugForPreview(
     .eq("slug", slug)
     .single();
 
-  if (error || !data) return undefined;
+  if (error) {
+    if (error.code === NO_ROWS_RETURNED) return undefined;
+    throw new Error(`記事の取得に失敗しました（${slug}）: ${error.message}`);
+  }
 
-  return toArticle(data);
+  return data ? toArticle(data) : undefined;
 }


### PR DESCRIPTION
## 背景

PR #159 の検証中に踏んだ問題。`src/lib/knowledge/index.ts` は取得に失敗しても空配列・`undefined` を返していた。

```ts
if (error || !data) return [];
```

実際に認証情報が無い状態で動かしたところ、**エラーにならず「記事0件」として正常描画された**。本番で Supabase の障害や設定ミスが起きると、次の状態になる。

- `sitemap.xml` が **記事0件の XML を 200 で配信** → Google にインデックス削除と解釈されうる
- `unstable_cache` は返り値をキャッシュするため、**一時的な障害の結果が最大24時間居座る**（例外はキャッシュされない）
- `getArticleBySlug` は一時障害でも `undefined` → `notFound()` となり、**公開中の記事が 404** になる

## 変更内容

| 関数 | 変更 |
|---|---|
| `getPublishedArticles` | エラーを投げる |
| `getArticleBySlug` | 0件（`PGRST116`）と障害を区別。0件は `undefined`、障害は投げる |
| `getArticleBySlugForPreview` | 同上 |
| `src/app/page.tsx` | ホームのみ `catch` して握り潰す |

## 設計判断

**ライブラリは事実を返し、握り潰すかは呼び出し側が決める。**

- `/knowledge`・`sitemap.xml` は記事が本体。空のまま 200 を返すと検索エンジンに「記事が無いサイト」と伝えるため、500 にして再試行させる
- ホームの記事セクションは補助的な要素。ここで 500 にするとトップ全体が落ち、損失のほうが大きい

`.single()` の0件は PostgREST が `PGRST116` を返すため、これで「記事が無い」と「取得に失敗した」を区別している。区別しないと一時障害が 404 に化ける。

## 検証（ローカル 3115）

service role キーを無効な値に差し替えて障害を再現し、キャッシュを失効させてから測定。

| | 修正前の挙動 | 修正後 |
|---|---|---|
| `/sitemap.xml` | 200 + 記事0件 | **500** ✅ |
| `/knowledge` | 200 + 記事0件 | **500** ✅ |
| `/`（トップ） | 200 | **200** ✅（記事セクションのみ欠落） |

正常系・復旧後も確認済み。

| 項目 | 結果 |
|---|---|
| `/` `/knowledge` `/sitemap.xml` `/knowledge/<slug>` | ✅ 200 |
| 存在しない slug | ✅ 404（500 になっていない） |
| `sitemap.xml` の記事数 | ✅ 4件 |
| 障害復旧後の自動正常化 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)