### PR TITLE
chore: Google Search Console の MCP サーバーを追加する

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -16,6 +16,13 @@
         "GOOGLE_APPLICATION_CREDENTIALS": "${HOME}/.config/gcloud/portfolio-ga4-sa.json",
         "GOOGLE_PROJECT_ID": "portfolio-ga4-shimizuyuta"
       }
+    },
+    "gsc": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-gsc"],
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "${HOME}/.config/gcloud/portfolio-ga4-sa.json"
+      }
     }
   }
 }


### PR DESCRIPTION
## 概要

`.mcp.json` に Google Search Console の MCP サーバー（[ahonn/mcp-server-gsc](https://github.com/ahonn/mcp-server-gsc)）を追加する。

## なぜ

GA4 の MCP は設定済みだが GSC が無く、検索クエリ・掲載順位・表示回数といった流入前のデータを Claude から参照できなかった。ブログ運用（`.claude/rules/blog.md`）で記事の改善方針を立てる際、GSC のクエリデータが判断材料として必要になる。

## 設計上の選択

**GA4 と同じサービスアカウント鍵（`portfolio-ga4-sa.json`）を使い回す構成にした。**

GSC 用に別鍵を発行することもできるが、鍵を増やすとローテーション時の管理対象と失効漏れのリスクが増える。両 API とも同一 GCP プロジェクト（`portfolio-ga4-shimizuyuta`）配下で、必要な権限も読み取りのみのため、1つの鍵に集約した。

`GOOGLE_PROJECT_ID` は GSC 側では不要なため指定していない（Search Console API はプロジェクトではなくサイト単位で権限を解決するため）。

## 前提となる設定（対応済み）

コード外の作業として以下が完了している：

- GCP プロジェクト `portfolio-ga4-shimizuyuta` で Search Console API を有効化
- Search Console に `ga4-mcp-reader@portfolio-ga4-shimizuyuta.iam.gserviceaccount.com` をユーザー追加

## 検証記録

- 検証者: Claude
- 内容: MCP を介さず、サービスアカウント鍵で Search Console API を直接呼び出して疎通確認
- 結果: ✅ 問題なし

```
GET webmasters/v3/sites → 200 OK
  https://www.ysdevelopment.jp/  (siteRestrictedUser)

POST searchAnalytics/query (2026-06-20〜07-17, dimensions=[query]) → 200 OK
  実データ取得を確認
```

- 備考: MCP サーバー経由での動作確認は、`.mcp.json` が Claude Code 起動時に読まれる仕様のため次回起動後に行う

## 確認事項

- [x] JSON として妥当（`python3 -m json.tool`）
- [x] Biome check 通過
- [ ] Claude Code 再起動後に `gsc` MCP ツールが利用可能になることの確認（マージ後）

`npx tsc --noEmit` は設定ファイルのみの変更で型に影響しないため省略した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
