### PR TITLE
feat: 記事公開時に GSC へ sitemap を自動再送信する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,14 @@ PREVIEW_TOKEN=your_preview_token_here
 # Google Analytics 4
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
+# Google Search Console（sitemap 自動再送信）
+# POST /api/revalidate から sitemap を GSC に再送信するためのサービスアカウント。
+# サービスアカウントを GSC のプロパティに「フル」権限で追加しておくこと。
+# 未設定の環境では sitemap 送信はスキップされる（revalidate 本体には影響しない）。
+GSC_SERVICE_ACCOUNT_EMAIL=xxx@yyy.iam.gserviceaccount.com
+# 秘密鍵。Vercel では改行を \n の 2 文字で 1 行として貼る（コード側で復元する）
+GSC_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+
 # Admin（ローカルのみ。Vercel には設定しない）
 ADMIN_ENABLED=
 NEXT_PUBLIC_ADMIN_ENABLED=

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,8 @@ NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
 # Google Search Console（sitemap 自動再送信）
 # POST /api/revalidate から sitemap を GSC に再送信するためのサービスアカウント。
-# サービスアカウントを GSC のプロパティに「フル」権限で追加しておくこと。
+# サービスアカウントを GSC のプロパティに「所有者」権限で追加しておくこと
+# （sitemaps.submit は所有者必須。フルユーザーだと 403 になる）。
 # 未設定の環境では sitemap 送信はスキップされる（revalidate 本体には影響しない）。
 GSC_SERVICE_ACCOUNT_EMAIL=xxx@yyy.iam.gserviceaccount.com
 # 秘密鍵。Vercel では改行を \n の 2 文字で 1 行として貼る（コード側で復元する）

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,6 +1,7 @@
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { verifyBearerToken } from "@/lib/api-auth";
+import { submitSitemap } from "@/lib/gsc";
 
 // 公開記事キャッシュの再検証エンドポイント。
 //
@@ -26,9 +27,29 @@ export async function POST(request: Request) {
 
   revalidateTag("published-articles");
 
+  // sitemap の再送信で GSC に再クロールを促す。
+  // Google が sitemap ping を廃止したため、公開反映と同じこのタイミングで
+  // Search Console API を叩くのが自動検知の唯一の経路になる。
+  // キャッシュ再検証が主目的なので、送信失敗で全体を 500 にはしない。
+  // 結果は sitemap フィールドで返し、成否はレスポンスで確認できるようにする。
+  let sitemap: string;
+  try {
+    const result = await submitSitemap();
+    if (result.ok) {
+      sitemap = "submitted";
+    } else if (result.skipped) {
+      sitemap = `skipped: ${result.reason}`;
+    } else {
+      sitemap = `failed: ${result.status} ${result.body}`;
+    }
+  } catch (error) {
+    sitemap = `error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
   return NextResponse.json({
     revalidated: true,
     tag: "published-articles",
+    sitemap,
     now: new Date().toISOString(),
   });
 }

--- a/src/lib/gsc.ts
+++ b/src/lib/gsc.ts
@@ -1,0 +1,119 @@
+import { createSign } from "node:crypto";
+import { SITE_URL } from "@/lib/site";
+
+// Google Search Console への sitemap 再送信。
+//
+// Google は 2023 年に sitemap ping（google.com/ping?sitemap=）を廃止したため、
+// 「公開したら GSC に読み直させる」正規の手段は Search Console API の
+// sitemaps.submit（PUT）だけになった。記事公開時に人間が叩く
+// /api/revalidate に相乗りさせ、そこからこの関数を呼ぶ。
+//
+// 認証はサービスアカウントの JWT を自前で組んで access token に交換する。
+// google-auth-library / googleapis を足す案もあったが、呼ぶのは 1 エンドポイント
+// だけで、依存を増やすほどの実装量ではないため node:crypto で完結させる。
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SCOPE = "https://www.googleapis.com/auth/webmasters";
+// GSC の URL プレフィックスプロパティは末尾スラッシュ付きで登録されている。
+// API の siteUrl は登録値と厳密一致する必要があるためスラッシュを付ける。
+const GSC_SITE_URL = `${SITE_URL}/`;
+const SITEMAP_URL = `${SITE_URL}/sitemap.xml`;
+
+export type SitemapSubmitResult =
+  | { ok: true }
+  | { ok: false; skipped: true; reason: string }
+  | { ok: false; skipped: false; status: number; body: string };
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// サービスアカウントの秘密鍵で署名した JWT を access token に交換する。
+async function fetchAccessToken(
+  clientEmail: string,
+  privateKey: string,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claim = base64url(
+    JSON.stringify({
+      iss: clientEmail,
+      scope: SCOPE,
+      aud: TOKEN_URL,
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+
+  const signingInput = `${header}.${claim}`;
+  const signature = base64url(
+    createSign("RSA-SHA256").update(signingInput).sign(privateKey),
+  );
+  const assertion = `${signingInput}.${signature}`;
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`token exchange failed: ${res.status} ${await res.text()}`);
+  }
+
+  const data = (await res.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error("token exchange returned no access_token");
+  }
+  return data.access_token;
+}
+
+export async function submitSitemap(): Promise<SitemapSubmitResult> {
+  const clientEmail = process.env.GSC_SERVICE_ACCOUNT_EMAIL?.trim();
+  // Vercel の環境変数では改行が \n という 2 文字で保存されるため、
+  // 実際の改行に戻さないと PEM のパースに失敗する。
+  const privateKey = process.env.GSC_SERVICE_ACCOUNT_PRIVATE_KEY?.replace(
+    /\\n/g,
+    "\n",
+  ).trim();
+
+  // 認証情報が無い環境（preview デプロイ・ローカル等）では送信をスキップする。
+  // revalidate 本体を失敗させないため、これは正常系として扱う。
+  if (!clientEmail || !privateKey) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: "GSC service account env vars are not set",
+    };
+  }
+
+  const accessToken = await fetchAccessToken(clientEmail, privateKey);
+
+  const endpoint = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(
+    GSC_SITE_URL,
+  )}/sitemaps/${encodeURIComponent(SITEMAP_URL)}`;
+
+  const res = await fetch(endpoint, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  // 成功時は 204 No Content。
+  if (!res.ok) {
+    return {
+      ok: false,
+      skipped: false,
+      status: res.status,
+      body: await res.text(),
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/gsc.ts
+++ b/src/lib/gsc.ts
@@ -11,6 +11,9 @@ import { SITE_URL } from "@/lib/site";
 // 認証はサービスアカウントの JWT を自前で組んで access token に交換する。
 // google-auth-library / googleapis を足す案もあったが、呼ぶのは 1 エンドポイント
 // だけで、依存を増やすほどの実装量ではないため node:crypto で完結させる。
+//
+// 前提: サービスアカウントは GSC プロパティに「所有者」権限で追加すること。
+// sitemaps.submit は所有者必須で、フルユーザーでは 403（PERMISSION_DENIED）になる。
 
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SCOPE = "https://www.googleapis.com/auth/webmasters";


### PR DESCRIPTION
## 目的

記事公開後、GSC が sitemap を再読み込みするまで最大 2ヶ月ほど間隔が空き、新記事の発見が遅れていた（`lastDownloaded` が 5/30 で停止、実際は 9 URL あるのに GSC 側は 5 件のまま）。公開のたびに GSC へ再クロールを促す。

## 変更内容

- `src/lib/gsc.ts` を追加。サービスアカウント JWT を `node:crypto` で生成 → access token 交換 → Search Console API の `sitemaps.submit`（PUT）を呼ぶ。
- `/api/revalidate` に相乗り。公開時に人間が叩く既存 webhook から `submitSitemap()` を呼ぶ。
- `.env.example` に `GSC_SERVICE_ACCOUNT_EMAIL` / `GSC_SERVICE_ACCOUNT_PRIVATE_KEY` を追記。

## 設計判断

- **なぜ sitemap 再送信か:** Google は 2023 年に sitemap ping を廃止済み。再送信が GSC に再読み込みを促す唯一の正規手段。
- **なぜ依存追加なし:** 叩くのは 1 エンドポイントのみ。`google-auth-library` 等を足さず `node:crypto` で JWT を自前署名。
- **なぜ best-effort:** 主目的はキャッシュ再検証。sitemap 送信失敗で全体を 500 にせず、結果は `sitemap` フィールドで返す。認証情報が無い環境（preview / local）はスキップ扱い。

## 稼働に必要な人間側の設定（マージ後）

- [ ] GCP でサービスアカウント作成、鍵（JSON）発行
- [ ] そのサービスアカウントを **GSC のプロパティに「所有者」権限で追加**（`sitemaps.submit` は所有者必須。フルユーザーだと 403 / PERMISSION_DENIED になる）
- [ ] Vercel に `GSC_SERVICE_ACCOUNT_EMAIL` / `GSC_SERVICE_ACCOUNT_PRIVATE_KEY` を設定し再デプロイ

## 確認

- [x] `npm run lint`（Biome）
- [x] `npx tsc --noEmit`
- [ ] 本番での実送信確認（上記の人間側設定の完了後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)