### PR TITLE
chore: サムネからブランド表記を外し出力先を変更する

### DIFF
--- a/.claude/commands/make-thumbnail.md
+++ b/.claude/commands/make-thumbnail.md
@@ -80,13 +80,11 @@ npx tsx --tsconfig scripts/thumbnail/tsconfig.json scripts/thumbnail/generate.ts
   --template <minimal|decorated> \
   --badge "<バッジ>" \
   --title '<見出し（\n で改行）>' \
-  --subtitle "<サブ>" \
-  --brand "TodoONada" \
-  --brand-suffix "note.com/daikidomon"
+  --subtitle "<サブ>"
 ```
 
 - `--title` は `\n` をシェルに食わせないため**シングルクォート**で囲む
-- `--brand` / `--brand-suffix` は `minimal` のみ有効
+- **`--brand` / `--brand-suffix` は使わない。** ブランド名・URL（TodoONada / note.com/daikidomon 等）はサムネに入れない方針。渡すとフッターに焼き込まれる
 - `decorated` にイラストを入れる場合は `--emoji 🪙`（Twemoji）か `--illustration <パス>`（自前画像）を足す
 
 #### `--emoji` を使う前に確認する（省略禁止）
@@ -95,7 +93,7 @@ npx tsx --tsconfig scripts/thumbnail/tsconfig.json scripts/thumbnail/generate.ts
 
 `docs/thumbnail-credits.md` に記載した帰属表示がサイトに設置済みかを確認する。**未設置なら `--emoji` を使わず、人間に判断を仰いで停止する。**
 
-出力先は `tmp/thumbnails/<slug>.png`（1200×630）。
+出力先は `tmp/サムネ/<slug>.png`（1200×630）。
 
 ### Step 6. 目視確認
 

--- a/scripts/thumbnail/generate.tsx
+++ b/scripts/thumbnail/generate.tsx
@@ -9,7 +9,7 @@ import { Decorated } from "./templates/decorated";
 import { Minimal } from "./templates/minimal";
 import { HEIGHT, type TemplateName, type ThumbnailInput, WIDTH } from "./theme";
 
-const OUT_DIR = join(process.cwd(), "tmp", "thumbnails");
+const OUT_DIR = join(process.cwd(), "tmp", "サムネ");
 
 const USAGE = `
 使い方:
@@ -17,7 +17,7 @@ const USAGE = `
     --slug <slug> --template <minimal|decorated> --title "見出し" [options]
 
 必須:
-  --slug          出力ファイル名（tmp/thumbnails/<slug>.png）
+  --slug          出力ファイル名（tmp/サムネ/<slug>.png）
   --title         主見出し。\\n で改行位置を指定できる
 
 任意:


### PR DESCRIPTION
## 概要

サムネイル生成まわりの2点を変更する。

## 変更内容

- **ブランド表記を廃止** — `--brand` / `--brand-suffix` を使わない方針に変更。ブランド名・URL（TodoONada / note.com/daikidomon 等）をサムネに焼き込まない
- **出力先を変更** — `tmp/thumbnails` → `tmp/サムネ`

対象ファイル：
- `.claude/commands/make-thumbnail.md`
- `scripts/thumbnail/generate.tsx`

## 確認

- `npx tsc --noEmit` パス
- lint はサムネ2ファイルに指摘なし（ローカルの articles-backup JSON 由来の指摘は本 PR と無関係。worktree には含まれない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)