### PR TITLE
chore: .claudeignore に .env.local を追加する

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -14,3 +14,5 @@ package-lock.json
 # Binary image assets (not useful for code understanding)
 public/images/
 public/logo/*.png
+
+.env.local


### PR DESCRIPTION
## 概要

`.claudeignore` に `.env.local` を追加し、秘匿値を含む環境ファイルを Claude の参照対象から除外する。

## 変更内容

- `.claudeignore` に `.env.local` を追記

## 確認

- 設定ファイル1行の追加のみ（ソースコード変更なし）のため lint / tsc は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)