### PR TITLE
feat: 記事詳細ページに構造化データ（JSON-LD）を追加する

### DIFF
--- a/src/app/knowledge/[slug]/page.tsx
+++ b/src/app/knowledge/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ArticleView } from "@/components/ArticleView";
 import { getArticleBySlug, getArticleBySlugForPreview } from "@/lib/knowledge";
+import { buildArticleJsonLd, serializeJsonLd } from "@/lib/knowledge/jsonld";
 import { isValidPreviewToken } from "@/lib/knowledge/preview";
 import { PreviewBanner } from "./_components/PreviewBanner";
 
@@ -101,6 +102,16 @@ export default async function ArticlePage({ params, searchParams }: Props) {
 
   return (
     <div className="bg-white min-h-screen">
+      {/* プレビューは noindex なので構造化データは公開記事だけに出す。 */}
+      {!isPreview &&
+        buildArticleJsonLd(article).map((jsonLd) => (
+          <script
+            key={jsonLd["@type"]}
+            type="application/ld+json"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD は serializeJsonLd で < をエスケープ済み
+            dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+          />
+        ))}
       {isPreview && (
         <PreviewBanner
           status={article.status}

--- a/src/lib/knowledge/jsonld.ts
+++ b/src/lib/knowledge/jsonld.ts
@@ -1,0 +1,82 @@
+import { SITE_URL } from "@/lib/site";
+import type { Article } from "./index";
+
+// 発行元（サイト運営者）。schema.org の Organization として使う。
+const PUBLISHER = {
+  "@type": "Organization",
+  name: "YSデベロップメント",
+  url: SITE_URL,
+  logo: {
+    "@type": "ImageObject",
+    url: `${SITE_URL}/logo/logo.png`,
+  },
+} as const;
+
+// 記事本文（Article.content）から description を作る。
+// generateMetadata と同じロジックにして、OGP と構造化データの説明文を揃える。
+function buildDescription(article: Article): string {
+  return article.excerpt || article.content.slice(0, 120).replace(/\n/g, " ");
+}
+
+// 記事詳細ページの構造化データ（BlogPosting）。
+// 検索結果での記事としての意味づけ・日付表示に使われる。
+function buildBlogPosting(article: Article) {
+  const url = `${SITE_URL}/knowledge/${article.slug}`;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    headline: article.title,
+    description: buildDescription(article),
+    // サムネイルが無い記事もあるため、あるときだけ image を出す。
+    ...(article.thumbnail_url ? { image: [article.thumbnail_url] } : {}),
+    datePublished: article.published_at ?? undefined,
+    dateModified: article.updated_at || article.published_at || undefined,
+    author: {
+      "@type": "Organization",
+      name: PUBLISHER.name,
+      url: PUBLISHER.url,
+    },
+    publisher: PUBLISHER,
+    // 業界タグ×テーマタグをキーワードとして渡す。
+    ...(article.tags.length > 0
+      ? { keywords: article.tags.map((tag) => tag.name).join(", ") }
+      : {}),
+  };
+}
+
+// パンくず（ホーム → ナレッジ → 記事）。検索結果のパンくず表示に使われる。
+function buildBreadcrumb(article: Article) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "ホーム", item: SITE_URL },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "ナレッジ",
+        item: `${SITE_URL}/knowledge`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: article.title,
+        item: `${SITE_URL}/knowledge/${article.slug}`,
+      },
+    ],
+  };
+}
+
+// 記事ページに埋め込む JSON-LD 群を1つの配列で返す。
+export function buildArticleJsonLd(article: Article) {
+  return [buildBlogPosting(article), buildBreadcrumb(article)];
+}
+
+// JSON-LD を <script> に埋め込む際の文字列化。
+// `<` を < にエスケープして、本文中の "</script>" 等による
+// スクリプト境界の破壊（XSS）を防ぐ。
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}


### PR DESCRIPTION
## 概要

記事詳細ページ（`/knowledge/[slug]`）に構造化データ（JSON-LD）を追加する。従来は `<title>`・OGP・canonical は揃っていたが JSON-LD が欠けていた。

Closes #168

## 変更内容

- **`src/lib/knowledge/jsonld.ts`（新規）**
  - `buildArticleJsonLd(article)` … `BlogPosting` + `BreadcrumbList` を配列で返す
  - `serializeJsonLd(data)` … `<` を `<` にエスケープし、本文中の `</script>` によるスクリプト境界破壊（XSS）を防ぐ
  - description は `generateMetadata` と同じロジック（`excerpt` 優先）で OGP と揃える
  - サムネイル・タグは存在するときだけ出力
- **`src/app/knowledge/[slug]/page.tsx`**
  - 非プレビュー時のみ `<script type="application/ld+json">` を描画（プレビューは noindex のため出さない）

## なぜこの設計か

- 組み立てロジックを `jsonld.ts` に分離し、page.tsx は取得・分岐・描画の責務に保つ
- `SITE_URL`・発行元情報を一箇所に集約
- publisher / author は運営者の `YSデベロップメント`（Organization）。人物名を勝手に作らない

## 確認

- [x] `npm run lint` パス
- [x] `npx tsc --noEmit` パス
- [x] モック記事で JSON-LD をシリアライズ検証：2本生成・`JSON.parse` 可能・`</script>` エスケープ動作を確認
- [ ] マージ後 [リッチリザルトテスト](https://search.google.com/test/rich-results) で本番URLを検証（人間）

🤖 Generated with [Claude Code](https://claude.com/claude-code)