### PR TITLE
chore: 施策の改善ログ(docs/experiments/)を git 管理外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ next-env.d.ts
 
 # 記事の旧版退避（ローカルのみで管理）
 /articles-backup/
+
+# 施策の改善ログ（ローカルのみで管理・他人に見せない）
+/docs/experiments/


### PR DESCRIPTION
## 目的

施策の効果評価レコード（`docs/experiments/`）はローカルのみで管理し、他人に見せない方針。誤ってコミット・push されないよう `.gitignore` に追加する。

## 変更内容

- `.gitignore` に `/docs/experiments/` を追加（`/articles-backup/` と同じローカル限定の扱い）

## 補足

- 記録ファイル自体はリポジトリに含めない（ローカル保持）。将来のセッションはローカルの `docs/experiments/` と memory の目印で評価を行う。

## 確認

- [x] `git check-ignore` で除外を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)