### PR TITLE
chore: viewport メタを明示しスマホ表示の前提を整える

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Noto_Sans_JP, Zen_Kaku_Gothic_New } from "next/font/google";
 import type { ReactNode } from "react";
 import { SITE_URL } from "@/lib/site";
@@ -28,6 +28,18 @@ export const metadata: Metadata = {
   description:
     "福祉×IT・AIの視点で発信するフリーランスエンジニア。社会福祉士の資格と6年のエンジニア経験を活かし、福祉業界のDX・AI導入支援を行っています。",
   metadataBase: new URL(SITE_URL),
+};
+
+// スマホ閲覧が主のため viewport を明示する。
+// - viewportFit: "cover" は iOS のノッチ／ホームバー領域（セーフエリア）まで
+//   背景を敷くための前提。env(safe-area-inset-*) を使う場合に必須。
+// - themeColor は公開ページが常時ライト（背景 white 固定）のため単一値。
+//   ダークテーマは .dark クラス未使用で公開側に出ないため dark 値は設けない。
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  themeColor: "#ffffff",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## 概要

スマホ閲覧が主のメディアだが、これまで `viewport` を Next のデフォルト任せにしていた。SP 最適化の基盤として `viewport` を明示する。

## 変更内容

`src/app/layout.tsx` に `export const viewport: Viewport` を追加：

- `width: "device-width"`, `initialScale: 1` — 明示（挙動はデフォルトと同じだが意図を明文化）
- `viewportFit: "cover"` — iOS のセーフエリア（ノッチ／ホームバー）対応の前提
- `themeColor: "#ffffff"` — モバイルブラウザ UI 色。公開ページは常時ライト（背景 white 固定）のため単一値

## なぜ

- **viewportFit**: 今後 `env(safe-area-inset-*)` を使うための土台。設定が無いと iOS でセーフエリアに背景が敷けない
- **themeColor 単一値**: ダークテーマは `.dark` クラス未使用で公開側に出ないため、`prefers-color-scheme: dark` に暗色を返すとページ（白）とブラウザ UI（黒）が不一致になる。それを避けるため単一値にした

## スコープ

記事ページ SP 最適化プランの Phase 1（基盤）。Phase 2（記事本文タイポグラフィ）は別 PR。

## 確認

- [x] `npm run lint`
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)