### PR TITLE
style: 記事本文をスマホ向けに最適化する

### DIFF
--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -28,7 +28,14 @@ function isImageOnlyParagraph(node: Element | undefined) {
 
 export function ArticleBody({ content }: { content: string }) {
   return (
-    <div className="prose prose-neutral prose-headings:font-bold prose-headings:text-gray-900 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded max-w-none">
+    // スマホ閲覧が主のため SP を基準に文字組みを整える:
+    // - base=16px を維持し md:prose-lg で PC のみ 18px に上げる
+    // - break-words: 長い英単語・URL で横スクロールが出ないようにする
+    // - prose-headings:scroll-mt-24: sticky ヘッダー裏に見出しが隠れないよう
+    //   目次アンカーの着地位置をずらす
+    // - prose-table を block+overflow-x-auto にし、幅広の表はページ全体でなく
+    //   表の中だけを横スクロールさせる（table を block 化する定石）
+    <div className="prose prose-neutral md:prose-lg max-w-none break-words prose-p:leading-[1.8] prose-headings:font-bold prose-headings:text-gray-900 prose-headings:scroll-mt-24 prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline prose-code:text-sky-700 prose-code:bg-sky-50 prose-code:px-1 prose-code:rounded prose-pre:overflow-x-auto prose-pre:text-sm prose-table:block prose-table:overflow-x-auto">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkFootnotes as never]}
         rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -119,7 +119,7 @@ export function ArticleView({
           {publishedDate && (
             <time
               dateTime={publishedAt ?? undefined}
-              className="text-xs text-gray-400 ml-auto"
+              className="text-xs text-gray-400 w-full md:w-auto md:ml-auto"
             >
               {publishedDate}
             </time>
@@ -135,7 +135,7 @@ export function ArticleView({
         {headings.length > 0 && (
           <nav
             aria-label="目次"
-            className="mb-10 rounded-xl border border-gray-200 bg-gray-50 px-6 py-5"
+            className="mb-10 rounded-xl border border-gray-200 bg-gray-50 px-4 py-5 md:px-6"
           >
             <p className="text-sm font-bold text-gray-700 mb-3">目次</p>
             <div className="space-y-2">


### PR DESCRIPTION
## 概要

スマホ閲覧が主のメディアだが、記事本文の `prose` に SP 向けの作り込みが無く、スマホでも PC でも同一の 16px・行間 1.75 のままだった。記事詳細ページ（`/knowledge/[slug]`）を SP 基準で読みやすく整える。

SP 最適化プランの Phase 2。基盤（viewport）は #172。

## 変更内容

### `src/components/ArticleBody.tsx`（prose ラッパ）
- `md:prose-lg` — PC のみ 18px に底上げ（SP は 16px 維持でモバイル最優先）
- `break-words` — 長い英単語・URL（ChatGPT / iPhone / URL 等）で横スクロールが出ないように
- `prose-headings:scroll-mt-24` — sticky ヘッダー裏に見出しが隠れる問題を解消（目次ジャンプの着地改善）
- `prose-table:block prose-table:overflow-x-auto` — 幅広の表をページ全体でなく表の中だけ横スクロール
- `prose-pre:overflow-x-auto prose-pre:text-sm` — コードブロックの横あふれ対策と可読性
- `prose-p:leading-[1.8]` — JP 可読性のため行間をわずかに緩める

### `src/components/ArticleView.tsx`
- メタ行の日付を SP では改行（`w-full md:w-auto md:ml-auto`）。狭幅でタグと潰れないように
- 目次ボックスの余白を外側コンテナと揃える（`px-6` → `px-4 md:px-6`）

## なぜ

- **table を block 化**するのは、`<table>` を `overflow-x-auto` で内部スクロールさせる定石。これをしないと幅広の表が 375px を超えてページごと横スクロールする
- **desktop を prose-lg に上げる**のは、SP の 16px は据え置きつつ広い画面の余白を活かすため。base を上げるとスマホが大きくなりすぎるので breakpoint で分けた

## スコープ

記事ページのみ。ホーム LP Hero / 実績マーキー / 余白統一は別 Issue（次フェーズ）。

## 確認

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] ブラウザ目視（375/390px）※検証記録コメントで別途報告

🤖 Generated with [Claude Code](https://claude.com/claude-code)