### PR TITLE
style: 記事一覧カードのサムネがSPで見切れる問題を修正

### DIFF
--- a/src/app/knowledge/KnowledgeClient.tsx
+++ b/src/app/knowledge/KnowledgeClient.tsx
@@ -130,7 +130,7 @@ export function KnowledgeClient({ articles }: { articles: Article[] }) {
                 className="group block rounded-xl overflow-hidden border border-gray-200 bg-white hover:shadow-lg transition-shadow duration-200"
               >
                 {/* サムネイル */}
-                <div className="relative h-36 overflow-hidden">
+                <div className="relative aspect-[1200/630] overflow-hidden">
                   {article.thumbnail_url ? (
                     <Image
                       src={article.thumbnail_url}


### PR DESCRIPTION
## 概要

ブログ記事一覧（`/knowledge`）のカードで、SP表示時にサムネイル画像が上下に見切れる問題を修正しました。

## 原因

サムネイルコンテナが高さ `h-36`（144px）固定＋`object-cover` になっていた。サムネは全て 1200×630（OGP標準比 ≈1.9:1）でタイトル文字入り。SPでは `grid-cols-1` によりカードが全幅（幅約350px）に広がり、本来なら高さ約184px必要な画像が144pxに詰められ、`object-cover` が上下を切り取ってタイトル文字が見切れていた。

## 変更

`src/app/knowledge/KnowledgeClient.tsx` のサムネイルコンテナ:

- `relative h-36` → `relative aspect-[1200/630]`

コンテナ比＝画像比になるため、`object-cover` でも切り取りが原理的に発生しない。デスクトップ4カラム時（幅約280px）の高さは約147pxで従来の144pxとほぼ同じ。フォールバックのグラデーション（`h-full`）も `aspect-[]` で高さが確定するため機能する。

## 確認

- [x] `npm run lint` パス
- [x] `npx tsc --noEmit` パス
- [x] ローカルでサムネ全体が欠けずに表示されることをブラウザ目視（※SP実機幅での撮影はブラウザ環境のウィンドウ最小幅制約で不可。CSSは決定的なため比率で切れは解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)